### PR TITLE
feat: Add prior unit outputs support for embedded processing

### DIFF
--- a/pkg/embedded/runtime/doc.go
+++ b/pkg/embedded/runtime/doc.go
@@ -106,7 +106,7 @@
 //	processor := runtime.NewEmbeddedProcessor(factory, cfg)
 //
 //	// Process embedded nodes
-//	output, err := processor.ProcessEmbeddedNodes(ctx, parentOutput, unit)
+//	output, err := processor.ProcessEmbeddedNodes(ctx, parentOutput, unit, priorUnitOutputs)
 //
 // # Implementing Custom Nodes
 //

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -63,7 +63,9 @@ type Output struct {
 type FieldMapping struct {
 	SourceNodeID         string   `json:"sourceNodeId"`
 	SourceEndpoint       string   `json:"sourceEndpoint"`
+	SourceSectionId      string   `json:"sourceSectionId,omitempty"` // e.g. "default" or "pluginError" for error-event handling
 	DestinationEndpoints []string `json:"destinationEndpoints"`
+	DestinationSectionId string   `json:"destinationSectionId,omitempty"`
 	DataType             string   `json:"dataType"`
 	Iterate              bool     `json:"iterate"`
 	IsEventTrigger       bool     `json:"isEventTrigger,omitempty"` // True when this mapping is an event trigger (conditional execution)


### PR DESCRIPTION
- Enhanced the ProcessEmbeddedNodes method to accept prior unit outputs, allowing downstream nodes to reference outputs from previous units.
- Updated related processing methods to utilize prior unit outputs, improving data handling and flow continuity.
- Introduced utility functions to build prior unit outputs from flat data and consumer graph result locations, facilitating better integration of historical data in subflows.
- Added logic to handle error-only outputs in event mappings, ensuring robust error management during processing.