### PR TITLE
Refactor action mapping and injection in runtime configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2128,5 +2128,6 @@ c.Messages.Publish(ctx, "subject", msg)
 
 ## Changelog
 
+- **2026-02-27**: `NormalizeRawConfig` now merges flattened nodeSchema values into the existing config instead of replacing it. This preserves top-level keys like `connection_id`, `connection`, and `manual_inputs` (from Elysium enrichment) when config uses nodeSchema format, fixing HTTP Client "connection_id is required" errors after enrichment.
 - **2025-11-24**: Standardized embedded processor plugin identifiers. Use `plugin-js`, `plugin-json-operations`, and `plugin-dateformatter` across workflows, configs, and tests.
 - **2025-02-20**: Added `plugin-http-client` embedded processor. Sends HTTP requests using a configured Nyx HTTP connection, optional headers (`manual_inputs`), and input payload. Outputs `status` (number) and `body` (byte). Requires connection enrichment from Elysium (connection_id → connection).

--- a/pkg/embedded/processors/dateformatter/config.go
+++ b/pkg/embedded/processors/dateformatter/config.go
@@ -2,7 +2,7 @@ package dateformatter
 
 import "fmt"
 
-// Config defines configuration for the date formatter (format operation).
+// Config defines configuration for the date formatter (format action).
 // Config keys match seed-node-schemas.sql Date Formatter: label, in_format, out_format.
 type Config struct {
 	InFormat    string `json:"in_format"`

--- a/pkg/embedded/processors/jsonops/config.go
+++ b/pkg/embedded/processors/jsonops/config.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 )
 
-// Config defines the configuration for JSON operations in embedded
+// Config defines the configuration for JSON actions in embedded
 type Config struct {
-	// Operation specifies which JSON operation to perform
+	// Action specifies which JSON action to perform
 	// Valid values: "parse", "produce"
-	Operation string `json:"operation"`
+	Action string `json:"action"`
 
 	// SchemaID is a reference to a schema in Morpheus (enriched by Elysium)
 	SchemaID string `json:"schema_id"`
@@ -17,7 +17,7 @@ type Config struct {
 	// Schema is the Icarus schema definition (optional, used if schema_id is not enriched)
 	Schema json.RawMessage `json:"schema,omitempty"`
 
-	// ApplyDefaults applies default values from schema (parse operation)
+	// ApplyDefaults applies default values from schema (parse action)
 	// Default: true for parse, false for produce
 	ApplyDefaults *bool `json:"apply_defaults,omitempty"`
 
@@ -29,26 +29,26 @@ type Config struct {
 	// Default: false for parse, true for produce
 	StrictValidation *bool `json:"strict_validation,omitempty"`
 
-	// Pretty formats the JSON before base64 encoding (produce operation only)
+	// Pretty formats the JSON before base64 encoding (produce action only)
 	// Default: false
 	Pretty bool `json:"pretty,omitempty"`
 }
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
-	// Operation is required
-	if c.Operation == "" {
-		return fmt.Errorf("operation field is required")
+	// Action is required
+	if c.Action == "" {
+		return fmt.Errorf("action field is required")
 	}
 
-	// Validate operation value
-	validOperations := map[string]bool{
+	// Validate action value
+	validActions := map[string]bool{
 		"parse":   true,
 		"produce": true,
 	}
 
-	if !validOperations[c.Operation] {
-		return fmt.Errorf("invalid operation '%s', must be one of: parse, produce", c.Operation)
+	if !validActions[c.Action] {
+		return fmt.Errorf("invalid action '%s', must be one of: parse, produce", c.Action)
 	}
 
 	// Must have either schema_id or schema
@@ -59,29 +59,29 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// GetApplyDefaults returns the apply_defaults value with operation-specific defaults
+// GetApplyDefaults returns the apply_defaults value with action-specific defaults
 func (c *Config) GetApplyDefaults() bool {
 	if c.ApplyDefaults != nil {
 		return *c.ApplyDefaults
 	}
 	// Default to true for parse (to fill in missing fields), false for produce
-	return c.Operation == "parse"
+	return c.Action == "parse"
 }
 
-// GetStructureData returns the structure_data value with operation-specific defaults
+// GetStructureData returns the structure_data value with action-specific defaults
 func (c *Config) GetStructureData() bool {
 	if c.StructureData != nil {
 		return *c.StructureData
 	}
 	// Default to false for parse (allow extra fields), true for produce (clean output)
-	return c.Operation == "produce"
+	return c.Action == "produce"
 }
 
-// GetStrictValidation returns the strict_validation value with operation-specific defaults
+// GetStrictValidation returns the strict_validation value with action-specific defaults
 func (c *Config) GetStrictValidation() bool {
 	if c.StrictValidation != nil {
 		return *c.StrictValidation
 	}
 	// Default to false for parse (lenient), true for produce (ensure valid output)
-	return c.Operation == "produce"
+	return c.Action == "produce"
 }

--- a/pkg/embedded/processors/jsonops/errors.go
+++ b/pkg/embedded/processors/jsonops/errors.go
@@ -6,14 +6,14 @@ import "fmt"
 // It includes context from the embedded runtime
 type ProcessingError struct {
 	NodeId    string
-	Operation string
+	Action    string
 	Message   string
 	ItemIndex int // -1 if not in iteration
 	Cause     error
 }
 
 func (e *ProcessingError) Error() string {
-	base := fmt.Sprintf("jsonops node '%s' operation '%s': %s", e.NodeId, e.Operation, e.Message)
+	base := fmt.Sprintf("jsonops node '%s' action '%s': %s", e.NodeId, e.Action, e.Message)
 
 	if e.ItemIndex >= 0 {
 		base = fmt.Sprintf("%s (item %d)", base, e.ItemIndex)
@@ -31,10 +31,10 @@ func (e *ProcessingError) Unwrap() error {
 }
 
 // NewProcessingError creates a new processing error
-func NewProcessingError(nodeId, operation, message string, itemIndex int, cause error) *ProcessingError {
+func NewProcessingError(nodeId, action, message string, itemIndex int, cause error) *ProcessingError {
 	return &ProcessingError{
 		NodeId:    nodeId,
-		Operation: operation,
+		Action:    action,
 		Message:   message,
 		ItemIndex: itemIndex,
 		Cause:     cause,
@@ -43,9 +43,9 @@ func NewProcessingError(nodeId, operation, message string, itemIndex int, cause 
 
 // ValidationError represents a schema validation failure
 type ValidationError struct {
-	NodeId    string
-	Operation string
-	Message   string
+	NodeId  string
+	Action  string
+	Message string
 	ItemIndex int
 	Errors    []string
 }
@@ -65,10 +65,10 @@ func (e *ValidationError) Error() string {
 }
 
 // NewValidationError creates a new validation error
-func NewValidationError(nodeId, operation, message string, itemIndex int, errors []string) *ValidationError {
+func NewValidationError(nodeId, action, message string, itemIndex int, errors []string) *ValidationError {
 	return &ValidationError{
-		NodeId:    nodeId,
-		Operation: operation,
+		NodeId:  nodeId,
+		Action:  action,
 		Message:   message,
 		ItemIndex: itemIndex,
 		Errors:    errors,

--- a/pkg/embedded/processors/jsonops/jsonops.go
+++ b/pkg/embedded/processors/jsonops/jsonops.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wehubfusion/Icarus/pkg/embedded/runtime"
 )
 
-// JsonOpsNode implements JSON operations (parse and produce) for embedded
+// JsonOpsNode implements JSON actions (parse and produce) for embedded
 type JsonOpsNode struct {
 	runtime.BaseNode
 }
@@ -24,7 +24,7 @@ func NewJsonOpsNode(config runtime.EmbeddedNodeConfig) (runtime.EmbeddedNode, er
 	}, nil
 }
 
-// Process executes the JSON operation (parse or produce)
+// Process executes the JSON action (parse or produce)
 func (n *JsonOpsNode) Process(input runtime.ProcessInput) runtime.ProcessOutput {
 	// Parse configuration
 	var cfg Config
@@ -37,8 +37,8 @@ func (n *JsonOpsNode) Process(input runtime.ProcessInput) runtime.ProcessOutput 
 		return runtime.ErrorOutput(NewConfigError(n.NodeId(), "invalid configuration", err))
 	}
 
-	// Route to appropriate operation
-	switch cfg.Operation {
+	// Route to appropriate action
+	switch cfg.Action {
 	case "parse":
 		return n.executeParse(input, &cfg)
 	case "produce":
@@ -46,7 +46,7 @@ func (n *JsonOpsNode) Process(input runtime.ProcessInput) runtime.ProcessOutput 
 	default:
 		return runtime.ErrorOutput(NewConfigError(
 			n.NodeId(),
-			fmt.Sprintf("unknown operation: %s", cfg.Operation),
+			fmt.Sprintf("unknown action: %s", cfg.Action),
 			nil,
 		))
 	}

--- a/pkg/embedded/processors/jsonops/tests/config_test.go
+++ b/pkg/embedded/processors/jsonops/tests/config_test.go
@@ -12,16 +12,16 @@ import (
 )
 
 func TestConfigValidate(t *testing.T) {
-	valid := jsonops.Config{Operation: "parse", SchemaID: "sid"}
+	valid := jsonops.Config{Action: "parse", SchemaID: "sid"}
 	if err := valid.Validate(); err != nil {
 		t.Fatalf("expected valid config, got %v", err)
 	}
 
 	cases := []jsonops.Config{
-		{},                                  // missing operation
-		{Operation: "bad", SchemaID: "sid"}, // invalid op
-		{Operation: "parse"},                // missing schema id and schema
-		{Operation: "produce", Schema: json.RawMessage{}}, // empty schema
+		{},                                  // missing action
+		{Action: "bad", SchemaID: "sid"}, // invalid op
+		{Action: "parse"},                // missing schema id and schema
+		{Action: "produce", Schema: json.RawMessage{}}, // empty schema
 	}
 	for i, cfg := range cases {
 		if err := cfg.Validate(); err == nil {
@@ -31,7 +31,7 @@ func TestConfigValidate(t *testing.T) {
 }
 
 func TestConfigDefaults(t *testing.T) {
-	cfgParse := jsonops.Config{Operation: "parse", SchemaID: "sid"}
+	cfgParse := jsonops.Config{Action: "parse", SchemaID: "sid"}
 	if !cfgParse.GetApplyDefaults() {
 		t.Fatalf("parse should default apply_defaults true")
 	}
@@ -42,7 +42,7 @@ func TestConfigDefaults(t *testing.T) {
 		t.Fatalf("parse should default strict_validation false")
 	}
 
-	cfgProduce := jsonops.Config{Operation: "produce", SchemaID: "sid"}
+	cfgProduce := jsonops.Config{Action: "produce", SchemaID: "sid"}
 	if cfgProduce.GetApplyDefaults() {
 		t.Fatalf("produce should default apply_defaults false")
 	}
@@ -59,7 +59,7 @@ func TestConfigExplicitOverrides(t *testing.T) {
 	structure := false
 	strict := false
 	cfg := jsonops.Config{
-		Operation:        "produce",
+		Action:        "produce",
 		SchemaID:         "sid",
 		ApplyDefaults:    &apply,
 		StructureData:    &structure,
@@ -147,8 +147,8 @@ func TestProcessEmptyConfig(t *testing.T) {
 	}
 }
 
-// TestProcessMissingOperation tests Process with missing operation field
-func TestProcessMissingOperation(t *testing.T) {
+// TestProcessMissingAction tests Process with missing action field
+func TestProcessMissingAction(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	config := jsonops.Config{SchemaID: "test-schema"}
 	rawConfig, _ := json.Marshal(config)
@@ -160,17 +160,17 @@ func TestProcessMissingOperation(t *testing.T) {
 
 	output := node.Process(input)
 	if output.Error == nil {
-		t.Fatalf("expected error for missing operation")
+		t.Fatalf("expected error for missing action")
 	}
 	if _, ok := output.Error.(*jsonops.ConfigError); !ok {
 		t.Fatalf("expected ConfigError, got %T: %v", output.Error, output.Error)
 	}
 }
 
-// TestProcessInvalidOperation tests Process with invalid operation value
-func TestProcessInvalidOperation(t *testing.T) {
+// TestProcessInvalidAction tests Process with invalid action value
+func TestProcessInvalidAction(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	config := jsonops.Config{Operation: "invalid-op", SchemaID: "test-schema"}
+	config := jsonops.Config{Action: "invalid-op", SchemaID: "test-schema"}
 	rawConfig, _ := json.Marshal(config)
 	input := createProcessInput(
 		map[string]interface{}{"data": "test"},
@@ -180,7 +180,7 @@ func TestProcessInvalidOperation(t *testing.T) {
 
 	output := node.Process(input)
 	if output.Error == nil {
-		t.Fatalf("expected error for invalid operation")
+		t.Fatalf("expected error for invalid action")
 	}
 	if _, ok := output.Error.(*jsonops.ConfigError); !ok {
 		t.Fatalf("expected ConfigError, got %T: %v", output.Error, output.Error)
@@ -190,7 +190,7 @@ func TestProcessInvalidOperation(t *testing.T) {
 // TestProcessMissingSchemaIDAndSchema tests Process with missing both schema_id and schema
 func TestProcessMissingSchemaIDAndSchema(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	config := jsonops.Config{Operation: "parse"}
+	config := jsonops.Config{Action: "parse"}
 	rawConfig, _ := json.Marshal(config)
 	input := createProcessInput(
 		map[string]interface{}{"data": "test"},
@@ -210,7 +210,7 @@ func TestProcessMissingSchemaIDAndSchema(t *testing.T) {
 // TestProcessEmptySchema tests Process with empty schema (when schema_id is not provided)
 func TestProcessEmptySchema(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	config := jsonops.Config{Operation: "produce", Schema: json.RawMessage{}}
+	config := jsonops.Config{Action: "produce", Schema: json.RawMessage{}}
 	rawConfig, _ := json.Marshal(config)
 	input := createProcessInput(
 		map[string]interface{}{"data": "test"},
@@ -227,11 +227,11 @@ func TestProcessEmptySchema(t *testing.T) {
 	}
 }
 
-// TestProcessUnknownOperation tests Process with unknown operation value
-func TestProcessUnknownOperation(t *testing.T) {
+// TestProcessUnknownAction tests Process with unknown action value
+func TestProcessUnknownAction(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	// Use a valid operation name but not "parse" or "produce"
-	config := jsonops.Config{Operation: "transform", SchemaID: "test-schema"}
+	// Use a valid action name but not "parse" or "produce"
+	config := jsonops.Config{Action: "transform", SchemaID: "test-schema"}
 	rawConfig, _ := json.Marshal(config)
 	input := createProcessInput(
 		map[string]interface{}{"data": "test"},
@@ -241,23 +241,23 @@ func TestProcessUnknownOperation(t *testing.T) {
 
 	output := node.Process(input)
 	if output.Error == nil {
-		t.Fatalf("expected error for unknown operation")
+		t.Fatalf("expected error for unknown action")
 	}
 	if _, ok := output.Error.(*jsonops.ConfigError); !ok {
 		t.Fatalf("expected ConfigError, got %T: %v", output.Error, output.Error)
 	}
-	// Verify error message contains the unknown operation
+	// Verify error message contains the unknown action
 	if output.Error.Error() == "" {
 		t.Fatalf("expected non-empty error message")
 	}
 }
 
-// TestProcessValidParseOperation tests Process with valid parse operation configuration
+// TestProcessValidParseAction tests Process with valid parse action configuration
 // Note: This tests routing to executeParse, but actual execution will fail without schema enrichment
-func TestProcessValidParseOperation(t *testing.T) {
+func TestProcessValidParseAction(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	config := jsonops.Config{
-		Operation: "parse",
+		Action: "parse",
 		SchemaID:  "test-schema",
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -279,12 +279,12 @@ func TestProcessValidParseOperation(t *testing.T) {
 	}
 }
 
-// TestProcessValidProduceOperation tests Process with valid produce operation configuration
+// TestProcessValidProduceAction tests Process with valid produce action configuration
 // Note: This tests routing to executeProduce, but actual execution will fail without schema enrichment
-func TestProcessValidProduceOperation(t *testing.T) {
+func TestProcessValidProduceAction(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	config := jsonops.Config{
-		Operation: "produce",
+		Action: "produce",
 		SchemaID:  "test-schema",
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -310,7 +310,7 @@ func TestProcessValidProduceOperation(t *testing.T) {
 func TestProcessWithSchemaID(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	config := jsonops.Config{
-		Operation: "parse",
+		Action: "parse",
 		SchemaID:  "test-schema-id",
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -340,7 +340,7 @@ func TestProcessWithSchema(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	schemaJSON := json.RawMessage(`{"type": "object", "properties": {"name": {"type": "string"}}}`)
 	config := jsonops.Config{
-		Operation: "produce",
+		Action: "produce",
 		Schema:    schemaJSON,
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -367,7 +367,7 @@ func TestProcessWithSchema(t *testing.T) {
 func TestProcessWithItemIndex(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	config := jsonops.Config{
-		Operation: "parse",
+		Action: "parse",
 		SchemaID:  "test-schema",
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -407,12 +407,12 @@ func TestProcessMalformedJSONVariations(t *testing.T) {
 		name      string
 		rawConfig json.RawMessage
 	}{
-		{"unclosed brace", json.RawMessage(`{"operation": "parse"`)},
-		{"unclosed string", json.RawMessage(`{"operation": "parse"`)},
-		{"invalid escape", json.RawMessage(`{"operation": "parse\z"}`)},
-		{"trailing comma", json.RawMessage(`{"operation": "parse",}`)},
-		{"null byte", json.RawMessage(`{"operation": "parse\000"}`)},
-		{"invalid unicode", json.RawMessage(`{"operation": "\uXXXX"}`)},
+		{"unclosed brace", json.RawMessage(`{"action": "parse"`)},
+		{"unclosed string", json.RawMessage(`{"action": "parse"`)},
+		{"invalid escape", json.RawMessage(`{"action": "parse\z"}`)},
+		{"trailing comma", json.RawMessage(`{"action": "parse",}`)},
+		{"null byte", json.RawMessage(`{"action": "parse\000"}`)},
+		{"invalid unicode", json.RawMessage(`{"action": "\uXXXX"}`)},
 	}
 
 	for _, tc := range testCases {
@@ -438,11 +438,11 @@ func TestProcessAllValidationErrors(t *testing.T) {
 		name   string
 		config jsonops.Config
 	}{
-		{"missing operation", jsonops.Config{SchemaID: "sid"}},
-		{"invalid operation", jsonops.Config{Operation: "bad", SchemaID: "sid"}},
-		{"missing schema_id and schema", jsonops.Config{Operation: "parse"}},
-		{"empty schema", jsonops.Config{Operation: "produce", Schema: json.RawMessage{}}},
-		{"unknown operation", jsonops.Config{Operation: "unknown", SchemaID: "sid"}},
+		{"missing action", jsonops.Config{SchemaID: "sid"}},
+		{"invalid action", jsonops.Config{Action: "bad", SchemaID: "sid"}},
+		{"missing schema_id and schema", jsonops.Config{Action: "parse"}},
+		{"empty schema", jsonops.Config{Action: "produce", Schema: json.RawMessage{}}},
+		{"unknown action", jsonops.Config{Action: "unknown", SchemaID: "sid"}},
 	}
 
 	for _, tc := range testCases {
@@ -460,14 +460,14 @@ func TestProcessAllValidationErrors(t *testing.T) {
 	}
 }
 
-// TestProcessOperationRouting tests that valid operations route correctly
-func TestProcessOperationRouting(t *testing.T) {
+// TestProcessActionRouting tests that valid actions route correctly
+func TestProcessActionRouting(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	inputData := map[string]interface{}{"data": "dGVzdA=="}
 
-	// Test parse operation routing
-	t.Run("parse operation", func(t *testing.T) {
-		config := jsonops.Config{Operation: "parse", SchemaID: "test-schema"}
+	// Test parse action routing
+	t.Run("parse action", func(t *testing.T) {
+		config := jsonops.Config{Action: "parse", SchemaID: "test-schema"}
 		rawConfig, _ := json.Marshal(config)
 		input := createProcessInput(inputData, rawConfig, -1)
 		output := node.Process(input)
@@ -487,9 +487,9 @@ func TestProcessOperationRouting(t *testing.T) {
 		}
 	})
 
-	// Test produce operation routing
-	t.Run("produce operation", func(t *testing.T) {
-		config := jsonops.Config{Operation: "produce", SchemaID: "test-schema"}
+	// Test produce action routing
+	t.Run("produce action", func(t *testing.T) {
+		config := jsonops.Config{Action: "produce", SchemaID: "test-schema"}
 		rawConfig, _ := json.Marshal(config)
 		input := createProcessInput(inputData, rawConfig, -1)
 		output := node.Process(input)
@@ -530,10 +530,10 @@ func TestProcessErrorMessages(t *testing.T) {
 		t.Fatalf("error message should mention config parsing: %s", errMsg)
 	}
 
-	// Test unknown operation error message
-	// Note: Invalid operations are caught by Validate() which returns "invalid operation"
-	// Only operations that pass validation but aren't "parse" or "produce" reach the default case
-	config := jsonops.Config{Operation: "invalid-op", SchemaID: "sid"}
+	// Test unknown action error message
+	// Note: Invalid actions are caught by Validate() which returns "invalid action"
+	// Only actions that pass validation but aren't "parse" or "produce" reach the default case
+	config := jsonops.Config{Action: "invalid-op", SchemaID: "sid"}
 	rawConfig, _ := json.Marshal(config)
 	input = createProcessInput(inputData, rawConfig, -1)
 	output = node.Process(input)
@@ -541,12 +541,12 @@ func TestProcessErrorMessages(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 	errMsg = output.Error.Error()
-	// Error should mention invalid operation (caught by Validate) or unknown operation (caught by switch)
-	if !contains(errMsg, "invalid operation") && !contains(errMsg, "unknown operation") {
-		t.Fatalf("error message should mention invalid/unknown operation: %s", errMsg)
+	// Error should mention invalid action (caught by Validate) or unknown action (caught by switch)
+	if !contains(errMsg, "invalid action") && !contains(errMsg, "unknown action") {
+		t.Fatalf("error message should mention invalid/unknown action: %s", errMsg)
 	}
 	if !contains(errMsg, "invalid-op") {
-		t.Fatalf("error message should contain the operation name: %s", errMsg)
+		t.Fatalf("error message should contain the action name: %s", errMsg)
 	}
 }
 
@@ -557,7 +557,7 @@ func TestProcessNodeIDInErrors(t *testing.T) {
 	for _, nodeID := range testNodeIDs {
 		t.Run(nodeID, func(t *testing.T) {
 			node := createTestNode(t, nodeID)
-			config := jsonops.Config{Operation: "invalid-op", SchemaID: "sid"}
+			config := jsonops.Config{Action: "invalid-op", SchemaID: "sid"}
 			rawConfig, _ := json.Marshal(config)
 			input := createProcessInput(map[string]interface{}{"data": "test"}, rawConfig, -1)
 			// Override NodeId in input to match the node
@@ -638,11 +638,11 @@ func TestProcessConfigWithWrongTypes(t *testing.T) {
 		name      string
 		rawConfig json.RawMessage
 	}{
-		{"operation as number", json.RawMessage(`{"operation": 123, "schema_id": "sid"}`)},
-		{"operation as boolean", json.RawMessage(`{"operation": true, "schema_id": "sid"}`)},
-		{"operation as array", json.RawMessage(`{"operation": ["parse"], "schema_id": "sid"}`)},
-		{"schema_id as number", json.RawMessage(`{"operation": "parse", "schema_id": 123}`)},
-		{"schema_id as boolean", json.RawMessage(`{"operation": "parse", "schema_id": true}`)},
+		{"action as number", json.RawMessage(`{"action": 123, "schema_id": "sid"}`)},
+		{"action as boolean", json.RawMessage(`{"action": true, "schema_id": "sid"}`)},
+		{"action as array", json.RawMessage(`{"action": ["parse"], "schema_id": "sid"}`)},
+		{"schema_id as number", json.RawMessage(`{"action": "parse", "schema_id": 123}`)},
+		{"schema_id as boolean", json.RawMessage(`{"action": "parse", "schema_id": true}`)},
 	}
 
 	for _, tc := range testCases {
@@ -667,7 +667,7 @@ func TestProcessConfigWithAllOptionalFields(t *testing.T) {
 	structureData := false
 	strictValidation := true
 	config := jsonops.Config{
-		Operation:        "parse",
+		Action:        "parse",
 		SchemaID:         "test-schema",
 		ApplyDefaults:    &applyDefaults,
 		StructureData:    &structureData,
@@ -699,7 +699,7 @@ func TestProcessConfigWithExtraFields(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	// Config with extra unknown fields
 	rawConfig := json.RawMessage(`{
-		"operation": "parse",
+		"action": "parse",
 		"schema_id": "test-schema",
 		"unknown_field": "should be ignored",
 		"another_field": 123,
@@ -794,7 +794,7 @@ func TestProcessWithDifferentNodeIDs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.nodeID, func(t *testing.T) {
 			node := createTestNode(t, tc.nodeID)
-			config := jsonops.Config{Operation: "parse", SchemaID: "test-schema"}
+			config := jsonops.Config{Action: "parse", SchemaID: "test-schema"}
 			rawConfig, _ := json.Marshal(config)
 			input := createProcessInput(
 				map[string]interface{}{"data": "dGVzdA=="},
@@ -812,14 +812,14 @@ func TestProcessWithDifferentNodeIDs(t *testing.T) {
 	}
 }
 
-// TestProcessCaseSensitiveOperations tests that operations are case-sensitive
-func TestProcessCaseSensitiveOperations(t *testing.T) {
+// TestProcessCaseSensitiveActions tests that actions are case-sensitive
+func TestProcessCaseSensitiveActions(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	inputData := map[string]interface{}{"data": "test"}
 
 	testCases := []struct {
 		name      string
-		operation string
+		action string
 		shouldErr bool
 	}{
 		{"uppercase PARSE", "PARSE", true},
@@ -832,7 +832,7 @@ func TestProcessCaseSensitiveOperations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config := jsonops.Config{Operation: tc.operation, SchemaID: "test-schema"}
+			config := jsonops.Config{Action: tc.action, SchemaID: "test-schema"}
 			rawConfig, _ := json.Marshal(config)
 			input := createProcessInput(inputData, rawConfig, -1)
 			output := node.Process(input)
@@ -865,7 +865,7 @@ func TestProcessWithSchemaAndSchemaID(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	schemaJSON := json.RawMessage(`{"type": "object"}`)
 	config := jsonops.Config{
-		Operation: "parse",
+		Action: "parse",
 		SchemaID:  "test-schema-id",
 		Schema:    schemaJSON,
 	}
@@ -905,12 +905,12 @@ func TestProcessMultipleInvalidJSONScenarios(t *testing.T) {
 		{"unclosed array", json.RawMessage(`[`)},
 		{"unclosed object", json.RawMessage(`{`)},
 		{"mismatched brackets", json.RawMessage(`{[}`)},
-		{"double comma", json.RawMessage(`{"operation": "parse",, "schema_id": "sid"}`)},
-		{"missing colon", json.RawMessage(`{"operation" "parse"}`)},
-		{"invalid number", json.RawMessage(`{"operation": 12.34.56}`)},
-		{"invalid true", json.RawMessage(`{"operation": tru}`)},
-		{"invalid false", json.RawMessage(`{"operation": fals}`)},
-		{"invalid null", json.RawMessage(`{"operation": nul}`)},
+		{"double comma", json.RawMessage(`{"action": "parse",, "schema_id": "sid"}`)},
+		{"missing colon", json.RawMessage(`{"action" "parse"}`)},
+		{"invalid number", json.RawMessage(`{"action": 12.34.56}`)},
+		{"invalid true", json.RawMessage(`{"action": tru}`)},
+		{"invalid false", json.RawMessage(`{"action": fals}`)},
+		{"invalid null", json.RawMessage(`{"action": nul}`)},
 	}
 
 	for _, tc := range testCases {
@@ -930,7 +930,7 @@ func TestProcessMultipleInvalidJSONScenarios(t *testing.T) {
 // TestProcessConfigErrorDetails tests detailed ConfigError properties
 func TestProcessConfigErrorDetails(t *testing.T) {
 	node := createTestNode(t, "test-node-xyz")
-	config := jsonops.Config{Operation: "unknown-op", SchemaID: "sid"}
+	config := jsonops.Config{Action: "unknown-op", SchemaID: "sid"}
 	rawConfig, _ := json.Marshal(config)
 	input := createProcessInput(
 		map[string]interface{}{"data": "test"},
@@ -962,11 +962,11 @@ func TestProcessConfigErrorDetails(t *testing.T) {
 	if !contains(fullErrorMsg, "invalid configuration") {
 		t.Fatalf("expected error to mention 'invalid configuration', got: %s", fullErrorMsg)
 	}
-	// The underlying cause should mention invalid operation
+	// The underlying cause should mention invalid action
 	if configErr.Cause != nil {
 		causeMsg := configErr.Cause.Error()
-		if !contains(causeMsg, "invalid operation") && !contains(causeMsg, "unknown operation") {
-			t.Fatalf("expected cause to mention 'invalid operation' or 'unknown operation', got: %s", causeMsg)
+		if !contains(causeMsg, "invalid action") && !contains(causeMsg, "unknown action") {
+			t.Fatalf("expected cause to mention 'invalid action' or 'unknown action', got: %s", causeMsg)
 		}
 	}
 }
@@ -974,7 +974,7 @@ func TestProcessConfigErrorDetails(t *testing.T) {
 // TestProcessNegativeItemIndex tests Process with various negative ItemIndex values
 func TestProcessNegativeItemIndex(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	config := jsonops.Config{Operation: "parse", SchemaID: "test-schema"}
+	config := jsonops.Config{Action: "parse", SchemaID: "test-schema"}
 	rawConfig, _ := json.Marshal(config)
 	inputData := map[string]interface{}{"data": "dGVzdA=="}
 
@@ -1001,7 +1001,7 @@ func TestProcessNegativeItemIndex(t *testing.T) {
 // TestProcessLargeItemIndex tests Process with very large ItemIndex values
 func TestProcessLargeItemIndex(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	config := jsonops.Config{Operation: "parse", SchemaID: "test-schema"}
+	config := jsonops.Config{Action: "parse", SchemaID: "test-schema"}
 	rawConfig, _ := json.Marshal(config)
 	inputData := map[string]interface{}{"data": "dGVzdA=="}
 
@@ -1023,17 +1023,17 @@ func TestProcessEmptyStringVsMissingField(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	inputData := map[string]interface{}{"data": "test"}
 
-	// Empty operation string should fail validation
-	config1 := jsonops.Config{Operation: "", SchemaID: "sid"}
+	// Empty action string should fail validation
+	config1 := jsonops.Config{Action: "", SchemaID: "sid"}
 	rawConfig1, _ := json.Marshal(config1)
 	input1 := createProcessInput(inputData, rawConfig1, -1)
 	output1 := node.Process(input1)
 	if output1.Error == nil {
-		t.Fatalf("expected error for empty operation string")
+		t.Fatalf("expected error for empty action string")
 	}
 
 	// Empty schema_id string with no schema should fail validation
-	config2 := jsonops.Config{Operation: "parse", SchemaID: ""}
+	config2 := jsonops.Config{Action: "parse", SchemaID: ""}
 	rawConfig2, _ := json.Marshal(config2)
 	input2 := createProcessInput(inputData, rawConfig2, -1)
 	output2 := node.Process(input2)
@@ -1046,7 +1046,7 @@ func TestProcessEmptyStringVsMissingField(t *testing.T) {
 func TestProcessUnicodeCharacters(t *testing.T) {
 	node := createTestNode(t, "node-测试-🎉")
 	config := jsonops.Config{
-		Operation: "parse",
+		Action: "parse",
 		SchemaID:  "schema-测试-中文",
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -1074,7 +1074,7 @@ func TestProcessVeryLongStrings(t *testing.T) {
 	// Create a very long schema_id
 	longSchemaID := strings.Repeat("a", 10000)
 	config := jsonops.Config{
-		Operation: "parse",
+		Action: "parse",
 		SchemaID:  longSchemaID,
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -1102,7 +1102,7 @@ func TestProcessBooleanFieldEdgeCases(t *testing.T) {
 
 	// Test with nil pointers (should use defaults)
 	config1 := jsonops.Config{
-		Operation: "parse",
+		Action: "parse",
 		SchemaID:  "test-schema",
 		// ApplyDefaults, StructureData, StrictValidation are nil
 	}
@@ -1118,7 +1118,7 @@ func TestProcessBooleanFieldEdgeCases(t *testing.T) {
 	structureFalse := false
 	strictFalse := false
 	config2 := jsonops.Config{
-		Operation:        "produce",
+		Action:        "produce",
 		SchemaID:         "test-schema",
 		ApplyDefaults:    &applyFalse,
 		StructureData:    &structureFalse,
@@ -1136,7 +1136,7 @@ func TestProcessBooleanFieldEdgeCases(t *testing.T) {
 	structureTrue := true
 	strictTrue := true
 	config3 := jsonops.Config{
-		Operation:        "parse",
+		Action:        "parse",
 		SchemaID:         "test-schema",
 		ApplyDefaults:    &applyTrue,
 		StructureData:    &structureTrue,
@@ -1153,7 +1153,7 @@ func TestProcessBooleanFieldEdgeCases(t *testing.T) {
 // TestProcessEmptyDataMap tests Process with empty data map
 func TestProcessEmptyDataMap(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	config := jsonops.Config{Operation: "parse", SchemaID: "test-schema"}
+	config := jsonops.Config{Action: "parse", SchemaID: "test-schema"}
 	rawConfig, _ := json.Marshal(config)
 	input := createProcessInput(
 		map[string]interface{}{}, // Empty data map
@@ -1179,7 +1179,7 @@ func TestProcessEmptyDataMap(t *testing.T) {
 // TestProcessNilDataMap tests Process with nil data map
 func TestProcessNilDataMap(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	config := jsonops.Config{Operation: "parse", SchemaID: "test-schema"}
+	config := jsonops.Config{Action: "parse", SchemaID: "test-schema"}
 	rawConfig, _ := json.Marshal(config)
 	input := createProcessInput(
 		nil, // Nil data map
@@ -1204,18 +1204,18 @@ func TestProcessControlCharactersInJSON(t *testing.T) {
 		name      string
 		rawConfig json.RawMessage
 	}{
-		{"newline in string", json.RawMessage(`{"operation": "parse\n", "schema_id": "sid"}`)},
-		{"tab in string", json.RawMessage(`{"operation": "parse\t", "schema_id": "sid"}`)},
-		{"carriage return", json.RawMessage(`{"operation": "parse\r", "schema_id": "sid"}`)},
-		{"backspace", json.RawMessage(`{"operation": "parse\b", "schema_id": "sid"}`)},
-		{"form feed", json.RawMessage(`{"operation": "parse\f", "schema_id": "sid"}`)},
+		{"newline in string", json.RawMessage(`{"action": "parse\n", "schema_id": "sid"}`)},
+		{"tab in string", json.RawMessage(`{"action": "parse\t", "schema_id": "sid"}`)},
+		{"carriage return", json.RawMessage(`{"action": "parse\r", "schema_id": "sid"}`)},
+		{"backspace", json.RawMessage(`{"action": "parse\b", "schema_id": "sid"}`)},
+		{"form feed", json.RawMessage(`{"action": "parse\f", "schema_id": "sid"}`)},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			input := createProcessInput(inputData, tc.rawConfig, -1)
 			output := node.Process(input)
-			// Control characters in strings are valid JSON, but operation will be invalid
+			// Control characters in strings are valid JSON, but action will be invalid
 			if output.Error == nil {
 				t.Fatalf("expected error for %s", tc.name)
 			}
@@ -1229,7 +1229,7 @@ func TestProcessDeeplyNestedJSON(t *testing.T) {
 	inputData := map[string]interface{}{"data": "test"}
 
 	// Create deeply nested JSON (though config doesn't support nesting, test that it's ignored)
-	deepNested := `{"operation": "parse", "schema_id": "sid", "nested": {"level1": {"level2": {"level3": {"level4": "value"}}}}}`
+	deepNested := `{"action": "parse", "schema_id": "sid", "nested": {"level1": {"level2": {"level3": {"level4": "value"}}}}}`
 	rawConfig := json.RawMessage(deepNested)
 	input := createProcessInput(inputData, rawConfig, -1)
 
@@ -1297,7 +1297,7 @@ func TestProcessSpecialCharactersInSchemaID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config := jsonops.Config{Operation: "parse", SchemaID: tc.schemaID}
+			config := jsonops.Config{Action: "parse", SchemaID: tc.schemaID}
 			rawConfig, _ := json.Marshal(config)
 			input := createProcessInput(inputData, rawConfig, -1)
 			output := node.Process(input)
@@ -1320,7 +1320,7 @@ func TestProcessNodeIdMethod(t *testing.T) {
 	for _, nodeID := range testNodeIDs {
 		t.Run(nodeID, func(t *testing.T) {
 			node := createTestNode(t, nodeID)
-			config := jsonops.Config{Operation: "invalid-op", SchemaID: "sid"}
+			config := jsonops.Config{Action: "invalid-op", SchemaID: "sid"}
 			rawConfig, _ := json.Marshal(config)
 			input := createProcessInput(
 				map[string]interface{}{"data": "test"},
@@ -1341,8 +1341,8 @@ func TestProcessNodeIdMethod(t *testing.T) {
 	}
 }
 
-// TestProcessOrderOfOperations tests that operations happen in correct order
-func TestProcessOrderOfOperations(t *testing.T) {
+// TestProcessOrderOfActions tests that actions happen in correct order
+func TestProcessOrderOfActions(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	inputData := map[string]interface{}{"data": "test"}
 
@@ -1363,7 +1363,7 @@ func TestProcessOrderOfOperations(t *testing.T) {
 
 	// Test that validation happens after parsing
 	// Valid JSON but invalid config should fail at validation stage
-	config2 := jsonops.Config{Operation: "bad-op", SchemaID: "sid"}
+	config2 := jsonops.Config{Action: "bad-op", SchemaID: "sid"}
 	rawConfig2, _ := json.Marshal(config2)
 	input2 := createProcessInput(inputData, rawConfig2, -1)
 	output2 := node.Process(input2)
@@ -1389,10 +1389,10 @@ func TestProcessWithEscapedCharacters(t *testing.T) {
 		rawConfig json.RawMessage
 		shouldErr bool
 	}{
-		{"escaped quotes", json.RawMessage(`{"operation": "parse", "schema_id": "schema\"with\"quotes"}`), false},
-		{"escaped backslash", json.RawMessage(`{"operation": "parse", "schema_id": "schema\\with\\backslashes"}`), false},
-		{"escaped newline", json.RawMessage(`{"operation": "parse", "schema_id": "schema\nwith\nnewline"}`), false},
-		{"unicode escape", json.RawMessage(`{"operation": "parse", "schema_id": "schema\u0041"}`), false},
+		{"escaped quotes", json.RawMessage(`{"action": "parse", "schema_id": "schema\"with\"quotes"}`), false},
+		{"escaped backslash", json.RawMessage(`{"action": "parse", "schema_id": "schema\\with\\backslashes"}`), false},
+		{"escaped newline", json.RawMessage(`{"action": "parse", "schema_id": "schema\nwith\nnewline"}`), false},
+		{"unicode escape", json.RawMessage(`{"action": "parse", "schema_id": "schema\u0041"}`), false},
 	}
 
 	for _, tc := range testCases {
@@ -1423,7 +1423,7 @@ func TestProcessWithEscapedCharacters(t *testing.T) {
 func TestProcessPrettyField(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	config := jsonops.Config{
-		Operation: "produce",
+		Action: "produce",
 		SchemaID:  "test-schema",
 		Pretty:    true,
 	}
@@ -1459,7 +1459,7 @@ func TestProcessAllOptionalFieldsCombinations(t *testing.T) {
 			for _, strict := range values {
 				t.Run(fmt.Sprintf("apply_%v_structure_%v_strict_%v", apply, structure, strict), func(t *testing.T) {
 					config := jsonops.Config{
-						Operation:        "parse",
+						Action:        "parse",
 						SchemaID:         "test-schema",
 						ApplyDefaults:    &apply,
 						StructureData:    &structure,
@@ -1487,7 +1487,7 @@ func TestProcessAllOptionalFieldsCombinations(t *testing.T) {
 // TestProcessContextPreservation tests that context is preserved in ProcessInput
 func TestProcessContextPreservation(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	config := jsonops.Config{Operation: "parse", SchemaID: "test-schema"}
+	config := jsonops.Config{Action: "parse", SchemaID: "test-schema"}
 	rawConfig, _ := json.Marshal(config)
 
 	// Test with background context
@@ -1526,7 +1526,7 @@ func TestProcessSwitchStatementCoverage(t *testing.T) {
 	inputData := map[string]interface{}{"data": "dGVzdA=="}
 
 	// Test parse case
-	config1 := jsonops.Config{Operation: "parse", SchemaID: "test-schema"}
+	config1 := jsonops.Config{Action: "parse", SchemaID: "test-schema"}
 	rawConfig1, _ := json.Marshal(config1)
 	input1 := createProcessInput(inputData, rawConfig1, -1)
 	output1 := node.Process(input1)
@@ -1541,7 +1541,7 @@ func TestProcessSwitchStatementCoverage(t *testing.T) {
 	}
 
 	// Test produce case
-	config2 := jsonops.Config{Operation: "produce", SchemaID: "test-schema"}
+	config2 := jsonops.Config{Action: "produce", SchemaID: "test-schema"}
 	rawConfig2, _ := json.Marshal(config2)
 	input2 := createProcessInput(inputData, rawConfig2, -1)
 	output2 := node.Process(input2)
@@ -1555,9 +1555,9 @@ func TestProcessSwitchStatementCoverage(t *testing.T) {
 		}
 	}
 
-	// Test default case (this is tricky - need an operation that passes validation but isn't parse/produce)
+	// Test default case (this is tricky - need an action that passes validation but isn't parse/produce)
 	// Since Validate() checks for parse/produce, we can't easily test default case
-	// But we can verify that operations that pass validation route correctly
+	// But we can verify that actions that pass validation route correctly
 }
 
 // Helper function to check if a string contains a substring (case-insensitive)

--- a/pkg/embedded/processors/strings/config.go
+++ b/pkg/embedded/processors/strings/config.go
@@ -11,17 +11,17 @@ type ManualInput struct {
 	Type string `json:"type"` // string | number | date
 }
 
-// Config defines configuration for strings operations.
-// Supports flat config from seed-node-schemas.sql: all keys except "operation"
+// Config defines configuration for strings actions.
+// Supports flat config from seed-node-schemas.sql: all keys except "action"
 // and "manual_inputs" are placed into Params.
 type Config struct {
-	Operation    string                 `json:"operation"`
+	Action       string                 `json:"action"`
 	Params       map[string]interface{} `json:"params"`
 	ManualInputs []ManualInput          `json:"manual_inputs"`
 }
 
 // UnmarshalJSON supports flat config (label, delimiter, separator, etc.) by
-// putting every key other than "operation" and "manual_inputs" into Params.
+// putting every key other than "action" and "manual_inputs" into Params.
 func (c *Config) UnmarshalJSON(data []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -30,12 +30,12 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	c.Params = make(map[string]interface{})
 	for k, v := range raw {
 		switch k {
-		case "operation":
+		case "action":
 			var s string
 			if err := json.Unmarshal(v, &s); err != nil {
 				return err
 			}
-			c.Operation = s
+			c.Action = s
 		case "manual_inputs":
 			var inputs []ManualInput
 			if err := json.Unmarshal(v, &inputs); err != nil {
@@ -61,7 +61,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-var supportedOperations = map[string]struct{}{
+var supportedActions = map[string]struct{}{
 	"concatenate":   {},
 	"split":         {},
 	"join":          {},
@@ -85,11 +85,11 @@ var supportedOperations = map[string]struct{}{
 
 // Validate checks if the configuration is valid.
 func (c *Config) Validate(nodeID string) error {
-	if c.Operation == "" {
-		return NewConfigError(nodeID, "operation", "operation cannot be empty", nil)
+	if c.Action == "" {
+		return NewConfigError(nodeID, "action", "action cannot be empty", nil)
 	}
-	if _, ok := supportedOperations[c.Operation]; !ok {
-		return NewConfigError(nodeID, "operation", fmt.Sprintf("unsupported operation '%s'", c.Operation), nil)
+	if _, ok := supportedActions[c.Action]; !ok {
+		return NewConfigError(nodeID, "action", fmt.Sprintf("unsupported action '%s'", c.Action), nil)
 	}
 
 	for i := range c.ManualInputs {

--- a/pkg/embedded/processors/strings/errors.go
+++ b/pkg/embedded/processors/strings/errors.go
@@ -23,24 +23,24 @@ func NewConfigError(nodeID, field, message string, err error) *ConfigError {
 	return &ConfigError{NodeID: nodeID, Field: field, Message: message, Err: err}
 }
 
-// OperationError represents an execution error during string operations.
-type OperationError struct {
+// ActionError represents an execution error during string actions.
+type ActionError struct {
 	NodeID    string
 	ItemIndex int
-	Operation string
+	Action    string
 	Message   string
 	Err       error
 }
 
-func (e *OperationError) Error() string {
+func (e *ActionError) Error() string {
 	if e.ItemIndex >= 0 {
-		return fmt.Sprintf("node %s: operation '%s' error at item %d: %s", e.NodeID, e.Operation, e.ItemIndex, e.Message)
+		return fmt.Sprintf("node %s: action '%s' error at item %d: %s", e.NodeID, e.Action, e.ItemIndex, e.Message)
 	}
-	return fmt.Sprintf("node %s: operation '%s' error: %s", e.NodeID, e.Operation, e.Message)
+	return fmt.Sprintf("node %s: action '%s' error: %s", e.NodeID, e.Action, e.Message)
 }
 
-func (e *OperationError) Unwrap() error { return e.Err }
+func (e *ActionError) Unwrap() error { return e.Err }
 
-func NewOperationError(nodeID string, itemIndex int, op, message string, err error) *OperationError {
-	return &OperationError{NodeID: nodeID, ItemIndex: itemIndex, Operation: op, Message: message, Err: err}
+func NewActionError(nodeID string, itemIndex int, action, message string, err error) *ActionError {
+	return &ActionError{NodeID: nodeID, ItemIndex: itemIndex, Action: action, Message: message, Err: err}
 }

--- a/pkg/embedded/processors/strings/operations.go
+++ b/pkg/embedded/processors/strings/operations.go
@@ -14,8 +14,8 @@ import (
 	"golang.org/x/text/language"
 )
 
-func executeOperation(nodeID string, itemIndex int, operation string, params map[string]interface{}, input map[string]interface{}) (interface{}, error) {
-	switch operation {
+func executeAction(nodeID string, itemIndex int, action string, params map[string]interface{}, input map[string]interface{}) (interface{}, error) {
+	switch action {
 	case "concatenate":
 		separator := getString(params, "separator", "")
 		parts := getStringSlice(params, "parts", nil)
@@ -50,7 +50,7 @@ func executeOperation(nodeID string, itemIndex int, operation string, params map
 		useRegex := getBool(params, "use_regex", false)
 		replaced, err := replace(str, old, newVal, count, useRegex)
 		if err != nil {
-			return nil, NewOperationError(nodeID, itemIndex, operation, fmt.Sprintf("replace failed: %v", err), err)
+			return nil, NewActionError(nodeID, itemIndex, action, fmt.Sprintf("replace failed: %v", err), err)
 		}
 		return replaced, nil
 
@@ -82,7 +82,7 @@ func executeOperation(nodeID string, itemIndex int, operation string, params map
 		useRegex := getBool(params, "use_regex", false)
 		ok, err := contains(str, sub, useRegex)
 		if err != nil {
-			return nil, NewOperationError(nodeID, itemIndex, operation, fmt.Sprintf("contains failed: %v", err), err)
+			return nil, NewActionError(nodeID, itemIndex, action, fmt.Sprintf("contains failed: %v", err), err)
 		}
 		return ok, nil
 
@@ -95,7 +95,7 @@ func executeOperation(nodeID string, itemIndex int, operation string, params map
 		pattern := getString(params, "pattern", "")
 		matches, err := regexExtract(str, pattern)
 		if err != nil {
-			return nil, NewOperationError(nodeID, itemIndex, operation, fmt.Sprintf("regex_extract failed: %v", err), err)
+			return nil, NewActionError(nodeID, itemIndex, action, fmt.Sprintf("regex_extract failed: %v", err), err)
 		}
 		return matches, nil
 
@@ -112,7 +112,7 @@ func executeOperation(nodeID string, itemIndex int, operation string, params map
 		str := getInputString(params, input, "")
 		decoded, err := base64Decode(str)
 		if err != nil {
-			return nil, NewOperationError(nodeID, itemIndex, operation, fmt.Sprintf("base64_decode failed: %v", err), err)
+			return nil, NewActionError(nodeID, itemIndex, action, fmt.Sprintf("base64_decode failed: %v", err), err)
 		}
 		return decoded, nil
 
@@ -124,7 +124,7 @@ func executeOperation(nodeID string, itemIndex int, operation string, params map
 		str := getInputString(params, input, "")
 		decoded, err := uriDecode(str)
 		if err != nil {
-			return nil, NewOperationError(nodeID, itemIndex, operation, fmt.Sprintf("uri_decode failed: %v", err), err)
+			return nil, NewActionError(nodeID, itemIndex, action, fmt.Sprintf("uri_decode failed: %v", err), err)
 		}
 		return decoded, nil
 
@@ -133,7 +133,7 @@ func executeOperation(nodeID string, itemIndex int, operation string, params map
 		return normalize(str), nil
 
 	default:
-		return nil, NewOperationError(nodeID, itemIndex, operation, "unsupported operation", nil)
+		return nil, NewActionError(nodeID, itemIndex, action, "unsupported action", nil)
 	}
 }
 
@@ -357,7 +357,7 @@ func removeDiacritics(s string) string {
 
 // --- map helpers ---
 
-// getInputString returns the main string for an operation: params["string"] if set,
+// getInputString returns the main string for an action: params["string"] if set,
 // else input["value"] (seed-node-schemas.sql input field key), else input["string"].
 func getInputString(params, input map[string]interface{}, defaultVal string) string {
 	if s := getString(params, "string", ""); s != "" {

--- a/pkg/embedded/processors/strings/strings.go
+++ b/pkg/embedded/processors/strings/strings.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wehubfusion/Icarus/pkg/embedded/runtime"
 )
 
-// StringsNode implements string operations for embedded.
+// StringsNode implements string actions for embedded.
 type StringsNode struct {
 	runtime.BaseNode
 }
@@ -20,7 +20,7 @@ func NewStringsNode(config runtime.EmbeddedNodeConfig) (runtime.EmbeddedNode, er
 	return &StringsNode{BaseNode: runtime.NewBaseNode(config)}, nil
 }
 
-// Process executes the configured string operation.
+// Process executes the configured string action.
 func (n *StringsNode) Process(input runtime.ProcessInput) runtime.ProcessOutput {
 	var cfg Config
 	if err := json.Unmarshal(input.RawConfig, &cfg); err != nil {
@@ -31,7 +31,7 @@ func (n *StringsNode) Process(input runtime.ProcessInput) runtime.ProcessOutput 
 		return runtime.ErrorOutput(err)
 	}
 
-	result, err := executeOperation(n.NodeId(), input.ItemIndex, cfg.Operation, cfg.Params, input.Data)
+	result, err := executeAction(n.NodeId(), input.ItemIndex, cfg.Action, cfg.Params, input.Data)
 	if err != nil {
 		return runtime.ErrorOutput(err)
 	}

--- a/pkg/embedded/processors/strings/tests/strings_test.go
+++ b/pkg/embedded/processors/strings/tests/strings_test.go
@@ -11,22 +11,22 @@ import (
 )
 
 func TestConfigValidate(t *testing.T) {
-	cfg := stringsproc.Config{Operation: "concatenate"}
+	cfg := stringsproc.Config{Action: "concatenate"}
 	if err := cfg.Validate("node1"); err != nil {
 		t.Fatalf("expected valid config, got %v", err)
 	}
 
-	cfg = stringsproc.Config{Operation: "bad"}
+	cfg = stringsproc.Config{Action: "bad"}
 	if err := cfg.Validate("node1"); err == nil {
-		t.Fatalf("expected invalid operation error")
+		t.Fatalf("expected invalid action error")
 	}
 
-	cfg = stringsproc.Config{Operation: "concatenate", ManualInputs: []stringsproc.ManualInput{{Name: "", Type: "string"}}}
+	cfg = stringsproc.Config{Action: "concatenate", ManualInputs: []stringsproc.ManualInput{{Name: "", Type: "string"}}}
 	if err := cfg.Validate("node1"); err == nil {
 		t.Fatalf("expected manual input validation error")
 	}
 
-	cfg = stringsproc.Config{Operation: "concatenate", ManualInputs: []stringsproc.ManualInput{{Name: "id", Type: "number"}}}
+	cfg = stringsproc.Config{Action: "concatenate", ManualInputs: []stringsproc.ManualInput{{Name: "id", Type: "number"}}}
 	if err := cfg.Validate("node1"); err != nil {
 		t.Fatalf("expected valid manual input config, got %v", err)
 	}
@@ -80,11 +80,11 @@ func TestProcessInvalidJSONConfig(t *testing.T) {
 	}
 }
 
-// TestProcessEmptyOperation tests Process with empty operation
-func TestProcessEmptyOperation(t *testing.T) {
+// TestProcessEmptyAction tests Process with empty action
+func TestProcessEmptyAction(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	config := stringsproc.Config{
-		Operation: "",
+		Action: "",
 		Params:    map[string]interface{}{},
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -96,18 +96,18 @@ func TestProcessEmptyOperation(t *testing.T) {
 
 	output := node.Process(input)
 	if output.Error == nil {
-		t.Fatalf("expected error for empty operation")
+		t.Fatalf("expected error for empty action")
 	}
 	if _, ok := output.Error.(*stringsproc.ConfigError); !ok {
 		t.Fatalf("expected ConfigError, got %T", output.Error)
 	}
 }
 
-// TestProcessUnsupportedOperation tests Process with unsupported operation
-func TestProcessUnsupportedOperation(t *testing.T) {
+// TestProcessUnsupportedAction tests Process with unsupported action
+func TestProcessUnsupportedAction(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 	config := stringsproc.Config{
-		Operation: "unsupported_op",
+		Action: "unsupported_op",
 		Params:    map[string]interface{}{},
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -119,7 +119,7 @@ func TestProcessUnsupportedOperation(t *testing.T) {
 
 	output := node.Process(input)
 	if output.Error == nil {
-		t.Fatalf("expected error for unsupported operation")
+		t.Fatalf("expected error for unsupported action")
 	}
 	if _, ok := output.Error.(*stringsproc.ConfigError); !ok {
 		t.Fatalf("expected ConfigError, got %T", output.Error)
@@ -132,7 +132,7 @@ func TestProcessInvalidManualInputs(t *testing.T) {
 
 	// Test with empty name
 	config := stringsproc.Config{
-		Operation: "concatenate",
+		Action: "concatenate",
 		Params:    map[string]interface{}{},
 		ManualInputs: []stringsproc.ManualInput{
 			{Name: "", Type: "string"},
@@ -155,7 +155,7 @@ func TestProcessInvalidManualInputs(t *testing.T) {
 
 	// Empty type is allowed and defaults to "string" (seed-node-schemas.sql concatenate/join only define name)
 	config = stringsproc.Config{
-		Operation: "concatenate",
+		Action: "concatenate",
 		Params:    map[string]interface{}{},
 		ManualInputs: []stringsproc.ManualInput{
 			{Name: "field1", Type: ""},
@@ -174,7 +174,7 @@ func TestProcessInvalidManualInputs(t *testing.T) {
 
 	// Test with invalid type
 	config = stringsproc.Config{
-		Operation: "concatenate",
+		Action: "concatenate",
 		Params:    map[string]interface{}{},
 		ManualInputs: []stringsproc.ManualInput{
 			{Name: "field1", Type: "invalid"},
@@ -193,13 +193,13 @@ func TestProcessInvalidManualInputs(t *testing.T) {
 	}
 }
 
-// TestProcessConcatenate tests Process with concatenate operation
+// TestProcessConcatenate tests Process with concatenate action
 func TestProcessConcatenate(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	// Test with separator and parts
 	config := stringsproc.Config{
-		Operation: "concatenate",
+		Action: "concatenate",
 		Params: map[string]interface{}{
 			"separator": "-",
 			"parts":     []string{"hello", "world"},
@@ -225,7 +225,7 @@ func TestProcessConcatenate(t *testing.T) {
 
 	// Test with empty separator
 	config = stringsproc.Config{
-		Operation: "concatenate",
+		Action: "concatenate",
 		Params: map[string]interface{}{
 			"separator": "",
 			"parts":     []string{"a", "b", "c"},
@@ -248,7 +248,7 @@ func TestProcessConcatenate(t *testing.T) {
 
 	// Test with parts from input data
 	config = stringsproc.Config{
-		Operation: "concatenate",
+		Action: "concatenate",
 		Params: map[string]interface{}{
 			"separator": " ",
 		},
@@ -272,12 +272,12 @@ func TestProcessConcatenate(t *testing.T) {
 	}
 }
 
-// TestProcessSplit tests Process with split operation
+// TestProcessSplit tests Process with split action
 func TestProcessSplit(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "split",
+		Action: "split",
 		Params: map[string]interface{}{
 			"string":    "a,b,c",
 			"delimiter": ",",
@@ -307,7 +307,7 @@ func TestProcessSplit(t *testing.T) {
 
 	// Test with string from input data
 	config = stringsproc.Config{
-		Operation: "split",
+		Action: "split",
 		Params: map[string]interface{}{
 			"delimiter": " ",
 		},
@@ -331,12 +331,12 @@ func TestProcessSplit(t *testing.T) {
 	}
 }
 
-// TestProcessJoin tests Process with join operation
+// TestProcessJoin tests Process with join action
 func TestProcessJoin(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "join",
+		Action: "join",
 		Params: map[string]interface{}{
 			"items":     []string{"a", "b", "c"},
 			"separator": "-",
@@ -359,7 +359,7 @@ func TestProcessJoin(t *testing.T) {
 
 	// seed-node-schemas.sql String Join: manual_inputs flow in as flat input keys
 	config2 := stringsproc.Config{
-		Operation: "join",
+		Action: "join",
 		Params: map[string]interface{}{
 			"separator": "-",
 		},
@@ -398,12 +398,12 @@ func TestProcessJoin(t *testing.T) {
 	}
 }
 
-// TestProcessTrim tests Process with trim operation
+// TestProcessTrim tests Process with trim action
 func TestProcessTrim(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "trim",
+		Action: "trim",
 		Params: map[string]interface{}{
 			"string": "  hello world  ",
 			"cutset": "",
@@ -426,7 +426,7 @@ func TestProcessTrim(t *testing.T) {
 
 	// Test with custom cutset
 	config = stringsproc.Config{
-		Operation: "trim",
+		Action: "trim",
 		Params: map[string]interface{}{
 			"string": "!!!hello!!!",
 			"cutset": "!",
@@ -448,13 +448,13 @@ func TestProcessTrim(t *testing.T) {
 	}
 }
 
-// TestProcessReplace tests Process with replace operation
+// TestProcessReplace tests Process with replace action
 func TestProcessReplace(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	// Test simple replace
 	config := stringsproc.Config{
-		Operation: "replace",
+		Action: "replace",
 		Params: map[string]interface{}{
 			"string": "hello world",
 			"old":    "world",
@@ -478,7 +478,7 @@ func TestProcessReplace(t *testing.T) {
 
 	// Test replace with count
 	config = stringsproc.Config{
-		Operation: "replace",
+		Action: "replace",
 		Params: map[string]interface{}{
 			"string": "foo foo foo",
 			"old":    "foo",
@@ -503,7 +503,7 @@ func TestProcessReplace(t *testing.T) {
 
 	// Test replace with regex
 	config = stringsproc.Config{
-		Operation: "replace",
+		Action: "replace",
 		Params: map[string]interface{}{
 			"string":   "hello123world456",
 			"old":      "\\d+",
@@ -527,12 +527,12 @@ func TestProcessReplace(t *testing.T) {
 	}
 }
 
-// TestProcessReplaceInvalidRegex tests Process with replace operation using invalid regex
+// TestProcessReplaceInvalidRegex tests Process with replace action using invalid regex
 func TestProcessReplaceInvalidRegex(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "replace",
+		Action: "replace",
 		Params: map[string]interface{}{
 			"string":   "hello world",
 			"old":      "[invalid",
@@ -551,17 +551,17 @@ func TestProcessReplaceInvalidRegex(t *testing.T) {
 	if output.Error == nil {
 		t.Fatalf("expected error for invalid regex")
 	}
-	if _, ok := output.Error.(*stringsproc.OperationError); !ok {
-		t.Fatalf("expected OperationError, got %T", output.Error)
+	if _, ok := output.Error.(*stringsproc.ActionError); !ok {
+		t.Fatalf("expected ActionError, got %T", output.Error)
 	}
 }
 
-// TestProcessSubstring tests Process with substring operation
+// TestProcessSubstring tests Process with substring action
 func TestProcessSubstring(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "substring",
+		Action: "substring",
 		Params: map[string]interface{}{
 			"string": "hello world",
 			"start":  0,
@@ -585,7 +585,7 @@ func TestProcessSubstring(t *testing.T) {
 
 	// Test with negative indices
 	config = stringsproc.Config{
-		Operation: "substring",
+		Action: "substring",
 		Params: map[string]interface{}{
 			"string": "hello world",
 			"start":  -5,
@@ -608,12 +608,12 @@ func TestProcessSubstring(t *testing.T) {
 	}
 }
 
-// TestProcessToUpper tests Process with to_upper operation
+// TestProcessToUpper tests Process with to_upper action
 func TestProcessToUpper(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "to_upper",
+		Action: "to_upper",
 		Params: map[string]interface{}{
 			"string": "hello world",
 		},
@@ -634,12 +634,12 @@ func TestProcessToUpper(t *testing.T) {
 	}
 }
 
-// TestProcessToLower tests Process with to_lower operation
+// TestProcessToLower tests Process with to_lower action
 func TestProcessToLower(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "to_lower",
+		Action: "to_lower",
 		Params: map[string]interface{}{
 			"string": "HELLO WORLD",
 		},
@@ -660,12 +660,12 @@ func TestProcessToLower(t *testing.T) {
 	}
 }
 
-// TestProcessTitleCase tests Process with title_case operation
+// TestProcessTitleCase tests Process with title_case action
 func TestProcessTitleCase(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "title_case",
+		Action: "title_case",
 		Params: map[string]interface{}{
 			"string": "hello world",
 		},
@@ -686,12 +686,12 @@ func TestProcessTitleCase(t *testing.T) {
 	}
 }
 
-// TestProcessCapitalize tests Process with capitalize operation
+// TestProcessCapitalize tests Process with capitalize action
 func TestProcessCapitalize(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "capitalize",
+		Action: "capitalize",
 		Params: map[string]interface{}{
 			"string": "hello world",
 		},
@@ -713,7 +713,7 @@ func TestProcessCapitalize(t *testing.T) {
 
 	// Test with empty string
 	config = stringsproc.Config{
-		Operation: "capitalize",
+		Action: "capitalize",
 		Params: map[string]interface{}{
 			"string": "",
 		},
@@ -734,13 +734,13 @@ func TestProcessCapitalize(t *testing.T) {
 	}
 }
 
-// TestProcessContains tests Process with contains operation
+// TestProcessContains tests Process with contains action
 func TestProcessContains(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	// Test simple contains
 	config := stringsproc.Config{
-		Operation: "contains",
+		Action: "contains",
 		Params: map[string]interface{}{
 			"string":    "hello world",
 			"substring": "world",
@@ -763,7 +763,7 @@ func TestProcessContains(t *testing.T) {
 
 	// Test with regex
 	config = stringsproc.Config{
-		Operation: "contains",
+		Action: "contains",
 		Params: map[string]interface{}{
 			"string":    "hello123world",
 			"substring": "\\d+",
@@ -787,7 +787,7 @@ func TestProcessContains(t *testing.T) {
 
 	// Test not contains
 	config = stringsproc.Config{
-		Operation: "contains",
+		Action: "contains",
 		Params: map[string]interface{}{
 			"string":    "hello world",
 			"substring": "xyz",
@@ -809,12 +809,12 @@ func TestProcessContains(t *testing.T) {
 	}
 }
 
-// TestProcessContainsInvalidRegex tests Process with contains operation using invalid regex
+// TestProcessContainsInvalidRegex tests Process with contains action using invalid regex
 func TestProcessContainsInvalidRegex(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "contains",
+		Action: "contains",
 		Params: map[string]interface{}{
 			"string":    "hello world",
 			"substring": "[invalid",
@@ -832,17 +832,17 @@ func TestProcessContainsInvalidRegex(t *testing.T) {
 	if output.Error == nil {
 		t.Fatalf("expected error for invalid regex")
 	}
-	if _, ok := output.Error.(*stringsproc.OperationError); !ok {
-		t.Fatalf("expected OperationError, got %T", output.Error)
+	if _, ok := output.Error.(*stringsproc.ActionError); !ok {
+		t.Fatalf("expected ActionError, got %T", output.Error)
 	}
 }
 
-// TestProcessLength tests Process with length operation
+// TestProcessLength tests Process with length action
 func TestProcessLength(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "length",
+		Action: "length",
 		Params: map[string]interface{}{
 			"string": "hello",
 		},
@@ -864,7 +864,7 @@ func TestProcessLength(t *testing.T) {
 
 	// Test with unicode
 	config = stringsproc.Config{
-		Operation: "length",
+		Action: "length",
 		Params: map[string]interface{}{
 			"string": "héllo",
 		},
@@ -885,12 +885,12 @@ func TestProcessLength(t *testing.T) {
 	}
 }
 
-// TestProcessRegexExtract tests Process with regex_extract operation
+// TestProcessRegexExtract tests Process with regex_extract action
 func TestProcessRegexExtract(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "regex_extract",
+		Action: "regex_extract",
 		Params: map[string]interface{}{
 			"string":  "hello123world456",
 			"pattern": "\\d+",
@@ -912,12 +912,12 @@ func TestProcessRegexExtract(t *testing.T) {
 	}
 }
 
-// TestProcessRegexExtractInvalidPattern tests Process with regex_extract operation using invalid pattern
+// TestProcessRegexExtractInvalidPattern tests Process with regex_extract action using invalid pattern
 func TestProcessRegexExtractInvalidPattern(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "regex_extract",
+		Action: "regex_extract",
 		Params: map[string]interface{}{
 			"string":  "hello world",
 			"pattern": "[invalid",
@@ -934,17 +934,17 @@ func TestProcessRegexExtractInvalidPattern(t *testing.T) {
 	if output.Error == nil {
 		t.Fatalf("expected error for invalid regex pattern")
 	}
-	if _, ok := output.Error.(*stringsproc.OperationError); !ok {
-		t.Fatalf("expected OperationError, got %T", output.Error)
+	if _, ok := output.Error.(*stringsproc.ActionError); !ok {
+		t.Fatalf("expected ActionError, got %T", output.Error)
 	}
 }
 
-// TestProcessFormat tests Process with format operation
+// TestProcessFormat tests Process with format action
 func TestProcessFormat(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "format",
+		Action: "format",
 		Params: map[string]interface{}{
 			"template": "Hello ${name}, you are {age} years old",
 			"data": map[string]interface{}{
@@ -970,7 +970,7 @@ func TestProcessFormat(t *testing.T) {
 
 	// seed-node-schemas.sql String Format: manual_inputs flow in as flat input keys
 	config2 := stringsproc.Config{
-		Operation: "format",
+		Action: "format",
 		Params: map[string]interface{}{
 			"template": "Hello {name}, welcome to {city}",
 		},
@@ -994,12 +994,12 @@ func TestProcessFormat(t *testing.T) {
 	}
 }
 
-// TestProcessBase64Encode tests Process with base64_encode operation
+// TestProcessBase64Encode tests Process with base64_encode action
 func TestProcessBase64Encode(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "base64_encode",
+		Action: "base64_encode",
 		Params: map[string]interface{}{
 			"string": "hello world",
 		},
@@ -1020,12 +1020,12 @@ func TestProcessBase64Encode(t *testing.T) {
 	}
 }
 
-// TestProcessBase64Decode tests Process with base64_decode operation
+// TestProcessBase64Decode tests Process with base64_decode action
 func TestProcessBase64Decode(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "base64_decode",
+		Action: "base64_decode",
 		Params: map[string]interface{}{
 			"string": "aGVsbG8gd29ybGQ=",
 		},
@@ -1046,12 +1046,12 @@ func TestProcessBase64Decode(t *testing.T) {
 	}
 }
 
-// TestProcessBase64DecodeInvalid tests Process with base64_decode operation using invalid base64
+// TestProcessBase64DecodeInvalid tests Process with base64_decode action using invalid base64
 func TestProcessBase64DecodeInvalid(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "base64_decode",
+		Action: "base64_decode",
 		Params: map[string]interface{}{
 			"string": "invalid!!!",
 		},
@@ -1067,17 +1067,17 @@ func TestProcessBase64DecodeInvalid(t *testing.T) {
 	if output.Error == nil {
 		t.Fatalf("expected error for invalid base64")
 	}
-	if _, ok := output.Error.(*stringsproc.OperationError); !ok {
-		t.Fatalf("expected OperationError, got %T", output.Error)
+	if _, ok := output.Error.(*stringsproc.ActionError); !ok {
+		t.Fatalf("expected ActionError, got %T", output.Error)
 	}
 }
 
-// TestProcessURIEncode tests Process with uri_encode operation
+// TestProcessURIEncode tests Process with uri_encode action
 func TestProcessURIEncode(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "uri_encode",
+		Action: "uri_encode",
 		Params: map[string]interface{}{
 			"string": "hello world",
 		},
@@ -1098,12 +1098,12 @@ func TestProcessURIEncode(t *testing.T) {
 	}
 }
 
-// TestProcessURIDecode tests Process with uri_decode operation
+// TestProcessURIDecode tests Process with uri_decode action
 func TestProcessURIDecode(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "uri_decode",
+		Action: "uri_decode",
 		Params: map[string]interface{}{
 			"string": "hello+world",
 		},
@@ -1124,12 +1124,12 @@ func TestProcessURIDecode(t *testing.T) {
 	}
 }
 
-// TestProcessURIDecodeInvalid tests Process with uri_decode operation using invalid URI encoding
+// TestProcessURIDecodeInvalid tests Process with uri_decode action using invalid URI encoding
 func TestProcessURIDecodeInvalid(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "uri_decode",
+		Action: "uri_decode",
 		Params: map[string]interface{}{
 			"string": "%ZZ",
 		},
@@ -1145,17 +1145,17 @@ func TestProcessURIDecodeInvalid(t *testing.T) {
 	if output.Error == nil {
 		t.Fatalf("expected error for invalid URI encoding")
 	}
-	if _, ok := output.Error.(*stringsproc.OperationError); !ok {
-		t.Fatalf("expected OperationError, got %T", output.Error)
+	if _, ok := output.Error.(*stringsproc.ActionError); !ok {
+		t.Fatalf("expected ActionError, got %T", output.Error)
 	}
 }
 
-// TestProcessNormalize tests Process with normalize operation
+// TestProcessNormalize tests Process with normalize action
 func TestProcessNormalize(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "normalize",
+		Action: "normalize",
 		Params: map[string]interface{}{
 			"string": "héllo wörld",
 		},
@@ -1181,7 +1181,7 @@ func TestProcessWithItemIndex(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
 	config := stringsproc.Config{
-		Operation: "to_upper",
+		Action: "to_upper",
 		Params: map[string]interface{}{
 			"string": "hello",
 		},
@@ -1226,9 +1226,9 @@ func TestProcessWithItemIndex(t *testing.T) {
 func TestProcessWithInputData(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
 
-	// Test operation that uses input data when params don't have the value
+	// Test action that uses input data when params don't have the value
 	config := stringsproc.Config{
-		Operation: "to_upper",
+		Action: "to_upper",
 		Params:    map[string]interface{}{},
 	}
 	rawConfig, _ := json.Marshal(config)
@@ -1249,44 +1249,44 @@ func TestProcessWithInputData(t *testing.T) {
 	}
 }
 
-// TestProcessAllOperations tests all supported operations to ensure they work
-func TestProcessAllOperations(t *testing.T) {
+// TestProcessAllActions tests all supported actions to ensure they work
+func TestProcessAllActions(t *testing.T) {
 	node := createTestNode(t, "test-node-1")
-	operations := []string{
+	actions := []string{
 		"concatenate", "split", "join", "trim", "replace", "substring",
 		"to_upper", "to_lower", "title_case", "capitalize", "contains",
 		"length", "regex_extract", "format", "base64_encode", "base64_decode",
 		"uri_encode", "uri_decode", "normalize",
 	}
 
-	for _, op := range operations {
+	for _, op := range actions {
 		config := stringsproc.Config{
-			Operation: op,
-			Params:    getDefaultParamsForOperation(op),
+			Action: op,
+			Params:    getDefaultParamsForAction(op),
 		}
 		rawConfig, err := json.Marshal(config)
 		if err != nil {
 			t.Fatalf("failed to marshal config for %s: %v", op, err)
 		}
 		input := createProcessInput(
-			getDefaultInputForOperation(op),
+			getDefaultInputForAction(op),
 			rawConfig,
 			0,
 		)
 
 		output := node.Process(input)
 		if output.Error != nil {
-			// Some operations may fail with default params, which is expected
+			// Some actions may fail with default params, which is expected
 			// We just want to ensure they don't crash
-			if _, ok := output.Error.(*stringsproc.OperationError); !ok {
-				t.Fatalf("operation %s returned unexpected error type: %T", op, output.Error)
+			if _, ok := output.Error.(*stringsproc.ActionError); !ok {
+				t.Fatalf("action %s returned unexpected error type: %T", op, output.Error)
 			}
 		}
 	}
 }
 
-// getDefaultParamsForOperation returns default params for testing each operation
-func getDefaultParamsForOperation(op string) map[string]interface{} {
+// getDefaultParamsForAction returns default params for testing each action
+func getDefaultParamsForAction(op string) map[string]interface{} {
 	switch op {
 	case "concatenate":
 		return map[string]interface{}{
@@ -1370,8 +1370,8 @@ func getDefaultParamsForOperation(op string) map[string]interface{} {
 	}
 }
 
-// getDefaultInputForOperation returns default input data for testing each operation
-func getDefaultInputForOperation(op string) map[string]interface{} {
+// getDefaultInputForAction returns default input data for testing each action
+func getDefaultInputForAction(op string) map[string]interface{} {
 	return map[string]interface{}{
 		"string": "hello",
 	}

--- a/pkg/embedded/runtime/config.go
+++ b/pkg/embedded/runtime/config.go
@@ -86,10 +86,10 @@ func flattenNodeSchemaConfig(m map[string]interface{}) map[string]interface{} {
 	return flat
 }
 
-// mapActionToOperation maps node schema Action (from execution plan) to processor operation.
-// Aligned with Apollo seed-node-schemas.sql and nodeconfiguration_service mapActionToOperation.
+// mapActionToValue maps node schema Action (from execution plan) to processor action value.
+// Aligned with Apollo seed-node-schemas.sql.
 // Returns empty string for unknown actions (no injection).
-func mapActionToOperation(action string) string {
+func mapActionToValue(action string) string {
 	switch action {
 	// plugin-json-operations
 	case "JSON Parser":
@@ -169,23 +169,23 @@ func mapActionToOperation(action string) string {
 	}
 }
 
-// InjectOperationFromAction takes normalized raw config and, when the node has an Action
-// that maps to an operation, sets config["operation"] to that value so processors (jsonops,
-// strings, csv, sftp, date formatter) act based on the execution plan action instead of
-// the operation field in config. Other config keys are unchanged.
+// InjectActionFromAction takes normalized raw config and, when the node has an Action
+// that maps to a value, sets config["action"] to that value so processors (jsonops,
+// strings, csv, sftp, date formatter) act based on the execution plan action.
+// Other config keys are unchanged.
 // If action is empty or has no mapping, returns normalizedRaw unchanged.
-// When config is empty (nil or []) but action has a mapping, returns minimal {"operation": "<op>"}
-// so operation-based nodes still work when config was not persisted.
-func InjectOperationFromAction(normalizedRaw json.RawMessage, pluginType, action string) json.RawMessage {
+// When config is empty (nil or []) but action has a mapping, returns minimal {"action": "<value>"}
+// so action-based nodes still work when config was not persisted.
+func InjectActionFromAction(normalizedRaw json.RawMessage, pluginType, action string) json.RawMessage {
 	if action == "" {
 		return normalizedRaw
 	}
-	op := mapActionToOperation(action)
+	op := mapActionToValue(action)
 	if op == "" {
 		return normalizedRaw
 	}
 	if len(normalizedRaw) == 0 {
-		out, _ := json.Marshal(map[string]interface{}{"operation": op})
+		out, _ := json.Marshal(map[string]interface{}{"action": op})
 		return out
 	}
 	var m map[string]interface{}
@@ -195,7 +195,7 @@ func InjectOperationFromAction(normalizedRaw json.RawMessage, pluginType, action
 	if m == nil {
 		m = make(map[string]interface{})
 	}
-	m["operation"] = op
+	m["action"] = op
 	out, err := json.Marshal(m)
 	if err != nil {
 		return normalizedRaw

--- a/pkg/embedded/runtime/config_test.go
+++ b/pkg/embedded/runtime/config_test.go
@@ -1,0 +1,74 @@
+package runtime
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeRawConfig_PreservesConnection(t *testing.T) {
+	// Config from Elysium enrichment: connection_id, connection, label, nodeSchema
+	raw := []byte(`{
+		"connection_id": "dd1f8d8e-6c45-49eb-8725-f5a41ae6aeac",
+		"connection": {"url": "https://example.com", "method": "POST"},
+		"label": "test",
+		"manual_inputs": [{"key": "", "value": ""}],
+		"nodeSchema": [{"key": "label", "value": "test"}]
+	}`)
+	result := NormalizeRawConfig(raw)
+	if len(result) == 0 {
+		t.Fatal("NormalizeRawConfig returned empty")
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if m["connection_id"] != "dd1f8d8e-6c45-49eb-8725-f5a41ae6aeac" {
+		t.Errorf("connection_id: got %v", m["connection_id"])
+	}
+	conn, ok := m["connection"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("connection: got %T", m["connection"])
+	}
+	if conn["url"] != "https://example.com" {
+		t.Errorf("connection.url: got %v", conn["url"])
+	}
+	if m["label"] != "test" {
+		t.Errorf("label: got %v", m["label"])
+	}
+	if _, ok := m["nodeSchema"]; ok {
+		t.Error("nodeSchema should be removed from output")
+	}
+}
+
+func TestNormalizeRawConfig_NodeSchemaOnly(t *testing.T) {
+	// Config with only nodeSchema (no connection keys)
+	raw := []byte(`{
+		"nodeSchema": [{"key": "script", "value": "x=1"}, {"key": "label", "value": "my-node"}]
+	}`)
+	result := NormalizeRawConfig(raw)
+	if len(result) == 0 {
+		t.Fatal("NormalizeRawConfig returned empty")
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if m["script"] != "x=1" {
+		t.Errorf("script: got %v", m["script"])
+	}
+	if m["label"] != "my-node" {
+		t.Errorf("label: got %v", m["label"])
+	}
+	if _, ok := m["nodeSchema"]; ok {
+		t.Error("nodeSchema should be removed from output")
+	}
+}
+
+func TestNormalizeRawConfig_NoNodeSchema(t *testing.T) {
+	// Config without nodeSchema - returns unchanged
+	raw := []byte(`{"connection_id": "abc", "label": "flat"}`)
+	result := NormalizeRawConfig(raw)
+	if string(result) != string(raw) {
+		t.Errorf("config without nodeSchema should be unchanged: got %s", string(result))
+	}
+}

--- a/pkg/embedded/runtime/subflow.go
+++ b/pkg/embedded/runtime/subflow.go
@@ -790,7 +790,7 @@ func (sp *SubflowProcessor) processDepthLevelParallel(
 				Ctx:           ctx,
 				Data:          input,
 				Config:        nil,
-				RawConfig:     InjectOperationFromAction(normalized, config.PluginType, config.Action),
+				RawConfig:     InjectActionFromAction(normalized, config.PluginType, config.Action),
 				NodeId:        config.NodeId,
 				PluginType:    config.PluginType,
 				Label:         config.Label,
@@ -933,7 +933,7 @@ func (sp *SubflowProcessor) processSingleNodeAtDepth(
 		Ctx:           ctx,
 		Data:          input,
 		Config:        nil,
-		RawConfig:     InjectOperationFromAction(normalized, config.PluginType, config.Action),
+		RawConfig:     InjectActionFromAction(normalized, config.PluginType, config.Action),
 		NodeId:        config.NodeId,
 		PluginType:    config.PluginType,
 		Label:         config.Label,
@@ -1052,8 +1052,8 @@ func (sp *SubflowProcessor) buildItemInput(
 					for i, seg := range segments {
 						if seg.Path == iter.ArrayPath {
 							currentSegIdx = i
-						break
-					}
+							break
+						}
 					}
 
 					// If the mapping's path doesn't include the current iteration array path,

--- a/pkg/embedded/runtime/types.go
+++ b/pkg/embedded/runtime/types.go
@@ -68,7 +68,7 @@ type EmbeddedNodeConfig struct {
 	Label string `json:"label"`
 	// PluginType identifies which processor handles this node
 	PluginType string `json:"pluginType"`
-	// Action is the node schema action (e.g. "JSON Parser", "CSV Producer"); used to derive operation for processors.
+	// Action is the node schema action (e.g. "JSON Parser", "CSV Producer"); used to derive action for processors.
 	Action string `json:"action,omitempty"`
 	// Embeddable indicates if this node can be embedded in a unit
 	Embeddable bool `json:"embeddable"`
@@ -171,7 +171,7 @@ type ExecutionUnit struct {
 	Type string `json:"type"`
 	// PluginType identifies which processor handles the parent node
 	PluginType string `json:"pluginType"`
-	// Action is the node schema action (e.g. "HTTP Trigger", "ESR Parser"); used to derive operation where applicable.
+	// Action is the node schema action (e.g. "HTTP Trigger", "ESR Parser"); used to derive action where applicable.
 	Action string `json:"action,omitempty"`
 	// Depth represents the unit's position in the execution graph
 	Depth int `json:"depth"`

--- a/pkg/schema/transformer_defaults_test.go
+++ b/pkg/schema/transformer_defaults_test.go
@@ -1,0 +1,745 @@
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestApplyDefaults_EmptyObject_SetsAllDefaults(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"name":   {Type: TypeString, Default: "unknown"},
+			"count":  {Type: TypeNumber, Default: 0.0},
+			"active": {Type: TypeBoolean, Default: true},
+		},
+	}
+	data := map[string]interface{}{}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+
+	if v, ok := obj["name"].(string); !ok || v != "unknown" {
+		t.Errorf("name: got %v (type %T), want \"unknown\"", obj["name"], obj["name"])
+	}
+	if v, ok := obj["count"].(float64); !ok || v != 0 {
+		t.Errorf("count: got %v (type %T), want 0", obj["count"], obj["count"])
+	}
+	if v, ok := obj["active"].(bool); !ok || !v {
+		t.Errorf("active: got %v (type %T), want true", obj["active"], obj["active"])
+	}
+}
+
+func TestApplyDefaults_NilDataObject_CreatesObjectAndSetsDefaults(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"status": {Type: TypeString, Default: "draft"},
+		},
+	}
+
+	out, err := tr.ApplyDefaults(nil, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	if obj["status"] != "draft" {
+		t.Errorf("status: got %v, want \"draft\"", obj["status"])
+	}
+}
+
+func TestApplyDefaults_ExistingValue_NotOverwritten(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"name": {Type: TypeString, Default: "default-name"},
+			"id":   {Type: TypeNumber, Default: 42.0},
+		},
+	}
+	data := map[string]interface{}{
+		"name": "custom-name",
+		"id":   float64(100),
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+
+	if obj["name"] != "custom-name" {
+		t.Errorf("name: got %v, want \"custom-name\"", obj["name"])
+	}
+	if v, ok := obj["id"].(float64); !ok || v != 100 {
+		t.Errorf("id: got %v, want 100", obj["id"])
+	}
+}
+
+func TestApplyDefaults_PartialObject_OnlyMissingFieldsGetDefaults(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"a": {Type: TypeString, Default: "default-a"},
+			"b": {Type: TypeString, Default: "default-b"},
+			"c": {Type: TypeString, Default: "default-c"},
+		},
+	}
+	data := map[string]interface{}{
+		"b": "provided-b",
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+
+	if obj["a"] != "default-a" {
+		t.Errorf("a: got %v, want \"default-a\"", obj["a"])
+	}
+	if obj["b"] != "provided-b" {
+		t.Errorf("b: got %v, want \"provided-b\"", obj["b"])
+	}
+	if obj["c"] != "default-c" {
+		t.Errorf("c: got %v, want \"default-c\"", obj["c"])
+	}
+}
+
+func TestApplyDefaults_NoDefault_FieldNotAdded(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"withDefault":    {Type: TypeString, Default: "yes"},
+			"withoutDefault": {Type: TypeString}, // Default is nil
+		},
+	}
+	data := map[string]interface{}{}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+
+	if obj["withDefault"] != "yes" {
+		t.Errorf("withDefault: got %v, want \"yes\"", obj["withDefault"])
+	}
+	if _, exists := obj["withoutDefault"]; exists {
+		t.Errorf("withoutDefault should not be present when no default defined")
+	}
+}
+
+func TestApplyDefaults_NestedObject_AppliesNestedDefaults(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"inner": {
+				Type: TypeObject,
+				Properties: map[string]*Property{
+					"nested": {Type: TypeString, Default: "nested-default"},
+				},
+			},
+		},
+	}
+	data := map[string]interface{}{
+		"inner": map[string]interface{}{},
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	inner, ok := obj["inner"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("inner: got %T, want map[string]interface{}", obj["inner"])
+	}
+	if inner["nested"] != "nested-default" {
+		t.Errorf("inner.nested: got %v, want \"nested-default\"", inner["nested"])
+	}
+}
+
+func TestApplyDefaults_MissingNestedObject_WithNestedDefaults_CreatesObjectWithDefaults(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"config": {
+				Type: TypeObject,
+				Properties: map[string]*Property{
+					"level": {Type: TypeString, Default: "info"},
+				},
+			},
+		},
+	}
+	data := map[string]interface{}{} // config key missing
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	config, ok := obj["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("config: got %T, want map[string]interface{}", obj["config"])
+	}
+	if config["level"] != "info" {
+		t.Errorf("config.level: got %v, want \"info\"", config["level"])
+	}
+}
+
+func TestApplyDefaults_ArrayOfObjects_AppliesItemDefaults(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeArray,
+		Items: &Property{
+			Type: TypeObject,
+			Properties: map[string]*Property{
+				"label": {Type: TypeString, Default: "item"},
+				"value": {Type: TypeNumber, Default: 1.0},
+			},
+		},
+	}
+	data := []interface{}{
+		map[string]interface{}{},
+		map[string]interface{}{"label": "custom"},
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	arr := out.([]interface{})
+	if len(arr) != 2 {
+		t.Fatalf("len(arr): got %d, want 2", len(arr))
+	}
+
+	item0 := arr[0].(map[string]interface{})
+	if item0["label"] != "item" || item0["value"].(float64) != 1 {
+		t.Errorf("item0: got label=%v value=%v, want label=\"item\" value=1", item0["label"], item0["value"])
+	}
+	item1 := arr[1].(map[string]interface{})
+	if item1["label"] != "custom" {
+		t.Errorf("item1.label: got %v, want \"custom\"", item1["label"])
+	}
+	if item1["value"].(float64) != 1 {
+		t.Errorf("item1.value: got %v, want 1", item1["value"])
+	}
+}
+
+func TestApplyDefaults_NilDataArray_ReturnsEmptySlice(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type:  TypeArray,
+		Items: &Property{Type: TypeString},
+	}
+
+	out, err := tr.ApplyDefaults(nil, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	arr, ok := out.([]interface{})
+	if !ok {
+		t.Fatalf("got %T, want []interface{}", out)
+	}
+	if len(arr) != 0 {
+		t.Errorf("len(arr): got %d, want 0", len(arr))
+	}
+}
+
+func TestApplyDefaults_WrongRootType_ReturnsError(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{Type: TypeObject, Properties: map[string]*Property{}}
+	data := []interface{}{"not", "object"}
+
+	_, err := tr.ApplyDefaults(data, schema)
+	if err == nil {
+		t.Error("expected error for array data with object schema")
+	}
+
+	schema2 := &Schema{Type: TypeArray, Items: &Property{Type: TypeString}}
+	data2 := map[string]interface{}{"x": "y"}
+	_, err = tr.ApplyDefaults(data2, schema2)
+	if err == nil {
+		t.Error("expected error for object data with array schema")
+	}
+}
+
+func TestApplyDefaults_DefaultZeroValues_StringEmptyAndNumberZero(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"emptyStr": {Type: TypeString, Default: ""},
+			"zero":     {Type: TypeNumber, Default: 0.0},
+			"falseVal": {Type: TypeBoolean, Default: false},
+		},
+	}
+	data := map[string]interface{}{}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+
+	if obj["emptyStr"] != "" {
+		t.Errorf("emptyStr: got %q, want \"\"", obj["emptyStr"])
+	}
+	if v, ok := obj["zero"].(float64); !ok || v != 0 {
+		t.Errorf("zero: got %v, want 0", obj["zero"])
+	}
+	if v, ok := obj["falseVal"].(bool); !ok || v {
+		t.Errorf("falseVal: got %v, want false", obj["falseVal"])
+	}
+}
+
+func TestApplyDefaults_UUID_MissingField_GeneratesUUID(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"id": {Type: TypeUUID},
+		},
+	}
+	data := map[string]interface{}{}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	id, ok := obj["id"].(string)
+	if !ok || id == "" {
+		t.Errorf("id: got %v, want non-empty string UUID", obj["id"])
+	}
+	// Basic UUID format check (8-4-4-4-12 hex)
+	if len(id) != 36 {
+		t.Errorf("id length: got %d, want 36", len(id))
+	}
+}
+
+func TestApplyDefaults_UUID_WithPrefixAndPostfix(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"urn": {Type: TypeUUID, Prefix: "urn:uuid:", Postfix: ""},
+		},
+	}
+	data := map[string]interface{}{}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	urn, ok := obj["urn"].(string)
+	if !ok {
+		t.Fatalf("urn: got %T", obj["urn"])
+	}
+	if len(urn) < 45 || urn[:9] != "urn:uuid:" {
+		t.Errorf("urn: got %q, want prefix \"urn:uuid:\"", urn)
+	}
+}
+
+func TestApplyCSVDefaults_AppliesColumnDefaults(t *testing.T) {
+	tr := NewTransformer()
+	csvSchema := &CSVSchema{
+		ColumnHeaders: map[string]*CSVColumn{
+			"name":  {Type: TypeString, Default: "N/A"},
+			"score": {Type: TypeNumber, Default: 0.0},
+		},
+	}
+	rows := []map[string]interface{}{
+		{"name": "alice"},
+		{},
+	}
+
+	out, err := tr.ApplyCSVDefaults(rows, csvSchema)
+	if err != nil {
+		t.Fatalf("ApplyCSVDefaults: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("rows: got %d, want 2", len(out))
+	}
+	// Row 0: name provided, score should get default
+	if out[0]["name"] != "alice" {
+		t.Errorf("row0.name: got %v, want \"alice\"", out[0]["name"])
+	}
+	if out[0]["score"].(float64) != 0 {
+		t.Errorf("row0.score: got %v, want 0", out[0]["score"])
+	}
+	// Row 1: both get defaults
+	if out[1]["name"] != "N/A" {
+		t.Errorf("row1.name: got %v, want \"N/A\"", out[1]["name"])
+	}
+	if out[1]["score"].(float64) != 0 {
+		t.Errorf("row1.score: got %v, want 0", out[1]["score"])
+	}
+}
+
+func TestApplyCSVDefaults_NilSchema_ReturnsRowsUnchanged(t *testing.T) {
+	tr := NewTransformer()
+	rows := []map[string]interface{}{{"a": "b"}}
+
+	out, err := tr.ApplyCSVDefaults(rows, nil)
+	if err != nil {
+		t.Fatalf("ApplyCSVDefaults: %v", err)
+	}
+	if len(out) != 1 || out[0]["a"] != "b" {
+		t.Errorf("rows unchanged: got %v", out)
+	}
+}
+
+func TestApplyDefaults_DefaultFromJSONNumber(t *testing.T) {
+	// JSON unmarshaling often gives numbers as float64
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"count": {Type: TypeNumber, Default: 42.0},
+		},
+	}
+	data := map[string]interface{}{}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	switch v := obj["count"].(type) {
+	case float64:
+		if v != 42 {
+			t.Errorf("count: got %v, want 42", v)
+		}
+	default:
+		t.Errorf("count: got %T (%v), want float64", obj["count"], obj["count"])
+	}
+}
+
+func TestApplyDefaults_DeeplyNested_DefaultsAppliedAtEachLevel(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"level1": {
+				Type: TypeObject,
+				Properties: map[string]*Property{
+					"level2": {
+						Type: TypeObject,
+						Properties: map[string]*Property{
+							"leaf": {Type: TypeString, Default: "deep"},
+						},
+					},
+				},
+			},
+		},
+	}
+	data := map[string]interface{}{
+		"level1": map[string]interface{}{
+			"level2": map[string]interface{}{},
+		},
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	l1, _ := obj["level1"].(map[string]interface{})
+	l2, _ := l1["level2"].(map[string]interface{})
+	if l2["leaf"] != "deep" {
+		t.Errorf("level1.level2.leaf: got %v, want \"deep\"", l2["leaf"])
+	}
+}
+
+func TestApplyDefaults_ObjectWithNoProperties_ReturnsDataUnchanged(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type:       TypeObject,
+		Properties: nil,
+	}
+	data := map[string]interface{}{"extra": "kept"}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	if obj["extra"] != "kept" {
+		t.Errorf("extra: got %v, want \"kept\"", obj["extra"])
+	}
+}
+
+func TestApplyDefaults_ArraySchemaWithItemsDefault_ItemDefaultsApplied(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeArray,
+		Items: &Property{
+			Type: TypeObject,
+			Properties: map[string]*Property{
+				"id":   {Type: TypeNumber, Default: 0.0},
+				"name": {Type: TypeString, Default: "unnamed"},
+			},
+		},
+	}
+	data := []interface{}{
+		map[string]interface{}{"id": float64(1)},
+		map[string]interface{}{"name": "only-name"},
+		map[string]interface{}{},
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	arr := out.([]interface{})
+
+	// First item: id provided, name should get default
+	item0 := arr[0].(map[string]interface{})
+	if item0["id"].(float64) != 1 || item0["name"] != "unnamed" {
+		t.Errorf("item0: got id=%v name=%v", item0["id"], item0["name"])
+	}
+	// Second item: name provided, id should get default
+	item1 := arr[1].(map[string]interface{})
+	if item1["id"].(float64) != 0 || item1["name"] != "only-name" {
+		t.Errorf("item1: got id=%v name=%v", item1["id"], item1["name"])
+	}
+	// Third item: both defaults
+	item2 := arr[2].(map[string]interface{})
+	if item2["id"].(float64) != 0 || item2["name"] != "unnamed" {
+		t.Errorf("item2: got id=%v name=%v", item2["id"], item2["name"])
+	}
+}
+
+// TestApplyDefaults_JSONRoundTrip ensures defaults applied to map[string]interface{}
+// (e.g. from json.Unmarshal) behave correctly when asserted back.
+func TestApplyDefaults_JSONRoundTrip(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"title": {Type: TypeString, Default: "Untitled"},
+		},
+	}
+	var data map[string]interface{}
+	_ = json.Unmarshal([]byte("{}"), &data)
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	if obj["title"] != "Untitled" {
+		t.Errorf("title: got %v, want \"Untitled\"", obj["title"])
+	}
+}
+
+// TestApplyDefaults_FromJSON_NestedObject verifies defaults work when data is
+// unmarshaled from JSON with nested objects (same types as json.Unmarshal produces).
+func TestApplyDefaults_FromJSON_NestedObject(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"user": {
+				Type: TypeObject,
+				Properties: map[string]*Property{
+					"name":  {Type: TypeString, Default: "guest"},
+					"role":  {Type: TypeString, Default: "viewer"},
+					"meta":  {Type: TypeObject, Properties: map[string]*Property{"env": {Type: TypeString, Default: "prod"}}},
+				},
+			},
+		},
+	}
+	// Real JSON: nested object with one field set, others missing
+	jsonStr := `{"user": {"name": "alice"}}`
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	user, ok := obj["user"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("user: got %T", obj["user"])
+	}
+	if user["name"] != "alice" {
+		t.Errorf("user.name: got %v, want \"alice\"", user["name"])
+	}
+	if user["role"] != "viewer" {
+		t.Errorf("user.role: got %v, want \"viewer\"", user["role"])
+	}
+	meta, ok := user["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("user.meta: got %T", user["meta"])
+	}
+	if meta["env"] != "prod" {
+		t.Errorf("user.meta.env: got %v, want \"prod\"", meta["env"])
+	}
+}
+
+// TestApplyDefaults_FromJSON_ArrayOfObjects verifies defaults work when data is
+// unmarshaled from JSON with an array of objects.
+func TestApplyDefaults_FromJSON_ArrayOfObjects(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"items": {
+				Type: TypeArray,
+				Items: &Property{
+					Type: TypeObject,
+					Properties: map[string]*Property{
+						"id":   {Type: TypeNumber, Default: 0.0},
+						"name": {Type: TypeString, Default: "item"},
+					},
+				},
+			},
+		},
+	}
+	jsonStr := `{"items": [{"id": 1}, {}, {"name": "custom"}]}`
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	items, ok := obj["items"].([]interface{})
+	if !ok {
+		t.Fatalf("items: got %T", obj["items"])
+	}
+	if len(items) != 3 {
+		t.Fatalf("len(items): got %d, want 3", len(items))
+	}
+	// First: id from JSON (float64), name gets default
+	item0 := items[0].(map[string]interface{})
+	if item0["id"].(float64) != 1 || item0["name"] != "item" {
+		t.Errorf("items[0]: got id=%v name=%v", item0["id"], item0["name"])
+	}
+	// Second: both defaults
+	item1 := items[1].(map[string]interface{})
+	if item1["id"].(float64) != 0 || item1["name"] != "item" {
+		t.Errorf("items[1]: got id=%v name=%v", item1["id"], item1["name"])
+	}
+	// Third: name from JSON, id gets default
+	item2 := items[2].(map[string]interface{})
+	if item2["id"].(float64) != 0 || item2["name"] != "custom" {
+		t.Errorf("items[2]: got id=%v name=%v", item2["id"], item2["name"])
+	}
+}
+
+// TestApplyDefaults_FromJSON_RootArray verifies defaults when root is an array
+// unmarshaled from JSON.
+func TestApplyDefaults_FromJSON_RootArray(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeArray,
+		Items: &Property{
+			Type: TypeObject,
+			Properties: map[string]*Property{
+				"value": {Type: TypeString, Default: "default"},
+			},
+		},
+	}
+	jsonStr := `[{"value": "a"}, {}]`
+	var data []interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	arr := out.([]interface{})
+	if len(arr) != 2 {
+		t.Fatalf("len: got %d, want 2", len(arr))
+	}
+	if arr[0].(map[string]interface{})["value"] != "a" {
+		t.Errorf("arr[0].value: got %v, want \"a\"", arr[0].(map[string]interface{})["value"])
+	}
+	if arr[1].(map[string]interface{})["value"] != "default" {
+		t.Errorf("arr[1].value: got %v, want \"default\"", arr[1].(map[string]interface{})["value"])
+	}
+}
+
+// TestApplyDefaults_FromJSON_NullNestedObject creates object and applies nested
+// defaults when JSON has explicit null for an object field.
+func TestApplyDefaults_FromJSON_NullNestedObject(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"config": {
+				Type: TypeObject,
+				Properties: map[string]*Property{
+					"level": {Type: TypeString, Default: "info"},
+				},
+			},
+		},
+	}
+	jsonStr := `{"config": null}`
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	config, ok := obj["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("config: got %T (null is treated as missing object, so we build {} with defaults)", obj["config"])
+	}
+	if config["level"] != "info" {
+		t.Errorf("config.level: got %v, want \"info\"", config["level"])
+	}
+}
+
+// TestApplyDefaults_FromJSON_ExplicitNullPrimitive documents current behavior:
+// when a key exists in JSON with value null, the default is NOT applied (key exists).
+func TestApplyDefaults_FromJSON_ExplicitNullPrimitive(t *testing.T) {
+	tr := NewTransformer()
+	schema := &Schema{
+		Type: TypeObject,
+		Properties: map[string]*Property{
+			"name": {Type: TypeString, Default: "default-name"},
+		},
+	}
+	jsonStr := `{"name": null}`
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	out, err := tr.ApplyDefaults(data, schema)
+	if err != nil {
+		t.Fatalf("ApplyDefaults: %v", err)
+	}
+	obj := out.(map[string]interface{})
+	// Current behavior: key "name" exists, so we do not apply default; value stays nil.
+	if obj["name"] != nil {
+		t.Errorf("name: current behavior is to not override explicit null; got %v", obj["name"])
+	}
+}


### PR DESCRIPTION
- Renamed `mapActionToOperation` to `mapActionToValue` to better reflect its purpose.
- Updated `InjectOperationFromAction` to `InjectActionFromAction` for consistency with the new naming.
- Changed the handling of action mappings in the configuration to set the "action" key instead of "operation".
- Added unit tests for `NormalizeRawConfig` to ensure proper behavior with various input scenarios.
- Introduced new tests for applying defaults in nested objects and arrays, ensuring defaults are correctly applied.
- Enhanced handling of UUID generation and default values in the transformer logic.