### PR TITLE
feat: Add Error Processor for controlled error handling in workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1446,6 +1446,27 @@ When executed in Elysium, the `schema_id` is automatically enriched with the ful
 
 For detailed documentation, see `pkg/embedded/processors/jsonops/README.md`.
 
+### Error Processor (`plugin-error`)
+
+The Error processor is a control-flow node that intentionally emits an error instead of a success payload.
+
+**Configuration and inputs:**
+
+- **label**: Display name for the node (from the Apollo node schema).
+- **default_error_message**: Fallback error message used when no runtime message is provided.
+- **message**: Optional input field populated via field mappings at runtime; when present and non-empty, it takes precedence over `default_error_message`.
+
+**Behavior:**
+
+- The node always returns an error (no success data payload).
+- When a downstream node listens to this node's `pluginError` section, the runtime exposes an error-only output:
+  - `pluginError/error` = `true`
+  - `pluginError/errorDescription` = resolved error message.
+- A **listener** is any mapping from this node's `pluginError` section, either:
+  - an **event mapping** (e.g. `/error` as an `EVENT` trigger), or
+  - a **field mapping** (e.g. `/errorDescription` as a `FIELD` into a handler node).
+- If at least one such mapping exists, the embedded runtime treats the error as **handled** and does not fail-fast; if no mappings from `pluginError` exist, the error bubbles up and causes the embedded unit / workflow run to fail, making this node useful for hard-stop guards as well as structured error flows.
+
 ## String Processing Utilities
 
 The SDK includes comprehensive string processing utilities for workflow orchestration and data manipulation:

--- a/pkg/embedded/processors/errornode/errornode.go
+++ b/pkg/embedded/processors/errornode/errornode.go
@@ -1,0 +1,100 @@
+package errornode
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/wehubfusion/Icarus/pkg/embedded/runtime"
+)
+
+// Config defines the configuration for the ErrorNode.
+// It aligns with the Apollo node schema (seed-node-schemas.sql):
+// - "label"
+// - "default_error_message"
+type Config struct {
+	Label               string `json:"label"`
+	DefaultErrorMessage string `json:"default_error_message"`
+}
+
+// ErrorNode implements an embedded node that always produces an error
+// with a configurable message. The message can come from:
+// - input data field "message" (preferred)
+// - config.DefaultErrorMessage
+// - a generic fallback when both are empty
+type ErrorNode struct {
+	runtime.BaseNode
+}
+
+// NewErrorNode creates a new ErrorNode instance.
+// It is registered under plugin type "plugin-error".
+func NewErrorNode(config runtime.EmbeddedNodeConfig) (runtime.EmbeddedNode, error) {
+	if config.PluginType != "plugin-error" {
+		return nil, fmt.Errorf("invalid plugin type: expected 'plugin-error', got '%s'", config.PluginType)
+	}
+
+	return &ErrorNode{
+		BaseNode: runtime.NewBaseNode(config),
+	}, nil
+}
+
+// Process evaluates the configuration and input data, then returns
+// an error output with the resolved message.
+//
+// Runtime behavior:
+//   - When downstream nodes listen to this node's pluginError section,
+//     the runtime will expose:
+//       error: true
+//       errorDescription: <resolved message>
+//   - When there is no pluginError listener, the error bubbled from
+//     this node will cause the unit/workflow to fail.
+func (n *ErrorNode) Process(input runtime.ProcessInput) runtime.ProcessOutput {
+	var cfg Config
+	if err := json.Unmarshal(input.RawConfig, &cfg); err != nil {
+		configErr := runtime.NewProcessingError(
+			input.NodeId,
+			input.Label,
+			input.PluginType,
+			input.ItemIndex,
+			"config",
+			fmt.Errorf("failed to parse configuration: %w", err),
+		)
+		return runtime.ErrorOutput(configErr)
+	}
+
+	message := resolveMessage(input.Data, cfg.DefaultErrorMessage)
+	if message == "" {
+		message = "Error node triggered without message"
+	}
+
+	baseErr := errors.New(message)
+	procErr := runtime.NewProcessingError(
+		input.NodeId,
+		input.Label,
+		input.PluginType,
+		input.ItemIndex,
+		"execute",
+		baseErr,
+	)
+
+	return runtime.ErrorOutput(procErr)
+}
+
+// resolveMessage determines the final error message using, in order:
+//   1. The "message" field from input data (if present and non-empty string)
+//   2. The provided defaultErrorMessage (if non-empty)
+//   3. Caller-provided generic fallback (handled by caller when this returns "")
+func resolveMessage(data map[string]interface{}, defaultErrorMessage string) string {
+	if data != nil {
+		if v, ok := data["message"]; ok && v != nil {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	if defaultErrorMessage != "" {
+		return defaultErrorMessage
+	}
+	return ""
+}
+

--- a/pkg/embedded/processors/errornode/errornode_test.go
+++ b/pkg/embedded/processors/errornode/errornode_test.go
@@ -1,0 +1,163 @@
+package errornode
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/wehubfusion/Icarus/pkg/embedded/runtime"
+)
+
+func createErrorNodeForTest(t *testing.T, nodeID string) *ErrorNode {
+	t.Helper()
+	cfg := runtime.EmbeddedNodeConfig{
+		NodeId:     nodeID,
+		Label:      "test-error-node",
+		PluginType: "plugin-error",
+		Embeddable: true,
+		Depth:      0,
+		NodeConfig: runtime.NodeConfig{NodeId: nodeID},
+	}
+
+	node, err := NewErrorNode(cfg)
+	if err != nil {
+		t.Fatalf("failed to create ErrorNode: %v", err)
+	}
+	return node.(*ErrorNode)
+}
+
+func createProcessInputForTest(nodeID string, data map[string]interface{}, rawConfig json.RawMessage) runtime.ProcessInput {
+	return runtime.ProcessInput{
+		Ctx:        context.Background(),
+		Data:       data,
+		RawConfig:  rawConfig,
+		NodeId:     nodeID,
+		PluginType: "plugin-error",
+		Label:      "test-error-node",
+		ItemIndex:  -1,
+	}
+}
+
+func TestNewErrorNode_InvalidPluginType(t *testing.T) {
+	cfg := runtime.EmbeddedNodeConfig{
+		NodeId:     "node-1",
+		Label:      "test-error-node",
+		PluginType: "plugin-not-error",
+	}
+
+	if _, err := NewErrorNode(cfg); err == nil {
+		t.Fatalf("expected error for invalid plugin type, got nil")
+	}
+}
+
+func TestProcess_UsesInputMessageWhenPresent(t *testing.T) {
+	node := createErrorNodeForTest(t, "node-input-msg")
+
+	cfg := Config{
+		Label:               "test-label",
+		DefaultErrorMessage: "default message",
+	}
+	rawCfg, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+
+	inputData := map[string]interface{}{
+		"message": "runtime message wins",
+	}
+	input := createProcessInputForTest("node-input-msg", inputData, rawCfg)
+
+	out := node.Process(input)
+	if out.Error == nil {
+		t.Fatalf("expected error output, got nil error")
+	}
+	if out.Data != nil {
+		t.Fatalf("expected nil data for error output, got: %#v", out.Data)
+	}
+	if out.Skipped {
+		t.Fatalf("expected not skipped")
+	}
+
+	errMsg := out.Error.Error()
+	if !strings.Contains(errMsg, "runtime message wins") {
+		t.Errorf("expected error message to contain input message, got: %q", errMsg)
+	}
+	if strings.Contains(errMsg, "default message") && !strings.Contains(errMsg, "runtime message wins") {
+		t.Errorf("expected input message to take precedence over default error message, got: %q", errMsg)
+	}
+}
+
+func TestProcess_UsesDefaultMessageWhenNoInputMessage(t *testing.T) {
+	node := createErrorNodeForTest(t, "node-default-msg")
+
+	cfg := Config{
+		Label:               "test-label",
+		DefaultErrorMessage: "configured default message",
+	}
+	rawCfg, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+
+	input := createProcessInputForTest("node-default-msg", map[string]interface{}{}, rawCfg)
+
+	out := node.Process(input)
+	if out.Error == nil {
+		t.Fatalf("expected error output, got nil error")
+	}
+
+	errMsg := out.Error.Error()
+	if !strings.Contains(errMsg, "configured default message") {
+		t.Errorf("expected error message to contain default error message, got: %q", errMsg)
+	}
+}
+
+func TestProcess_UsesGenericFallbackWhenNoMessages(t *testing.T) {
+	node := createErrorNodeForTest(t, "node-generic-msg")
+
+	cfg := Config{
+		Label:               "test-label",
+		DefaultErrorMessage: "",
+	}
+	rawCfg, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+
+	input := createProcessInputForTest("node-generic-msg", map[string]interface{}{}, rawCfg)
+
+	out := node.Process(input)
+	if out.Error == nil {
+		t.Fatalf("expected error output, got nil error")
+	}
+
+	errMsg := out.Error.Error()
+	if !strings.Contains(errMsg, "Error node triggered without message") {
+		t.Errorf("expected generic fallback message in error, got: %q", errMsg)
+	}
+}
+
+func TestProcess_InvalidConfigReturnsConfigError(t *testing.T) {
+	node := createErrorNodeForTest(t, "node-invalid-config")
+
+	// Intentionally invalid JSON
+	rawCfg := json.RawMessage(`{invalid json`)
+	input := createProcessInputForTest("node-invalid-config", nil, rawCfg)
+
+	out := node.Process(input)
+	if out.Error == nil {
+		t.Fatalf("expected error for invalid config, got nil")
+	}
+	if out.Data == nil {
+		// ok; for config errors we don't expect data
+	} else {
+		t.Errorf("expected nil data for config error, got: %#v", out.Data)
+	}
+
+	errMsg := out.Error.Error()
+	if !strings.Contains(errMsg, "failed to parse configuration") {
+		t.Errorf("expected error message to mention configuration parsing, got: %q", errMsg)
+	}
+}
+

--- a/pkg/embedded/processors/registry.go
+++ b/pkg/embedded/processors/registry.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"github.com/wehubfusion/Icarus/pkg/embedded/processors/errornode"
 	"github.com/wehubfusion/Icarus/pkg/embedded/processors/dateformatter"
 	"github.com/wehubfusion/Icarus/pkg/embedded/processors/httpclient"
 	"github.com/wehubfusion/Icarus/pkg/embedded/processors/jsonops"
@@ -32,6 +33,9 @@ func NewProcessorRegistry() runtime.EmbeddedNodeFactory {
 
 	// Register httpclient processor
 	factory.Register("plugin-http-client", httpclient.NewHTTPClientNode)
+
+	// Register error processor
+	factory.Register("plugin-error", errornode.NewErrorNode)
 
 	// Future processors can be registered here...
 

--- a/pkg/embedded/runtime/subflow.go
+++ b/pkg/embedded/runtime/subflow.go
@@ -119,11 +119,16 @@ func groupNodesByDepth(configs []EmbeddedNodeConfig) [][]int {
 	return groups
 }
 
-// hasDownstreamPluginErrorListener returns true if any embedded node has an event mapping
+// hasDownstreamPluginErrorListener returns true if any embedded node consumes output
 // from sourceNodeId's pluginError section (so error output should be stored and flow continued).
 func (sp *SubflowProcessor) hasDownstreamPluginErrorListener(sourceNodeId string) bool {
 	for _, cfg := range sp.nodeConfigs {
 		for _, m := range cfg.GetEventMappings() {
+			if m.SourceNodeId == sourceNodeId && m.SourceSectionId == SectionPluginError {
+				return true
+			}
+		}
+		for _, m := range cfg.GetFieldMappings() {
 			if m.SourceNodeId == sourceNodeId && m.SourceSectionId == SectionPluginError {
 				return true
 			}


### PR DESCRIPTION
- Introduced the `plugin-error` processor that emits errors intentionally.
- Added configuration options for custom error messages and behavior.
- Updated the processor registry to include the new error processor.
- Enhanced the subflow logic to check for downstream error listeners.