### PR TITLE
feat: Add support for 'event' data type in ManualInput and enhance JS…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dlclark/regexp2 v1.11.4
 	github.com/dop251/goja v0.0.0-20251103141225-af2ceb9156d7
 	github.com/getsentry/sentry-go v0.35.3
-	github.com/google/cel-go v0.27.0
+	github.com/google/cel-go v0.28.0
 	github.com/google/uuid v1.6.0
 	github.com/nats-io/nats.go v1.46.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9v
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
-github.com/google/cel-go v0.27.0/go.mod h1:tTJ11FWqnhw5KKpnWpvW9CJC3Y9GK4EIS0WXnBbebzw=
+github.com/google/cel-go v0.28.0 h1:KjSWstCpz/MN5t4a8gnGJNIYUsJRpdi/r97xWDphIQc=
+github.com/google/cel-go v0.28.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE2YxKWtnnQls6rQjjW5oV7qg2U=

--- a/pkg/cel/engine.go
+++ b/pkg/cel/engine.go
@@ -116,7 +116,7 @@ func (e *Engine) EvaluateRules(rules []CompiledRule, iter ScopeIterator) ([]Viol
 			path := iter.ErrorPath(cr.Rule, i)
 			msg := strings.TrimSpace(cr.Rule.Message)
 			if msg == "" {
-					msg = defaultAssertionFailureMessage(cr.Rule)
+				msg = defaultAssertionFailureMessage(cr.Rule, path)
 			}
 			sev := strings.TrimSpace(cr.Rule.Severity)
 			if sev == "" {
@@ -136,19 +136,26 @@ func (e *Engine) EvaluateRules(rules []CompiledRule, iter ScopeIterator) ([]Viol
 
 // defaultAssertionFailureMessage builds a clear default when the rule omits "message".
 // It includes the rule display name, id, and optional HL7/error path.
-func defaultAssertionFailureMessage(rule InputRule) string {
+func defaultAssertionFailureMessage(rule InputRule, path string) string {
 	name := strings.TrimSpace(rule.Name)
 	id := strings.TrimSpace(rule.ID)
+	path = strings.TrimSpace(path)
 
 	var b strings.Builder
 	b.WriteString("Assertion failed for validation rule ")
 	switch {
 	case name != "":
 		fmt.Fprintf(&b, "%q", name)
+		if id != "" {
+			fmt.Fprintf(&b, " (id: %s)", id)
+		}
 	case id != "":
 		fmt.Fprintf(&b, "(id: %s)", id)
 	default:
 		b.WriteString("(unknown rule)")
+	}
+	if path != "" {
+		fmt.Fprintf(&b, " at %s", path)
 	}
 	b.WriteByte('.')
 	return b.String()

--- a/pkg/cel/engine_test.go
+++ b/pkg/cel/engine_test.go
@@ -32,8 +32,8 @@ func TestDefaultAssertionFailureMessage(t *testing.T) {
 	for _, tc := range cases {
 		got := defaultAssertionFailureMessage(tc.rule, tc.path)
 		if got != tc.want {
-			t.Errorf("defaultAssertionFailureMessage(rule id=%q name=%q, path=%q) = %q, want %q",
-				tc.rule.ID, tc.rule.Name, tc.path, got, tc.want)
+			t.Errorf("defaultAssertionFailureMessage(rule id=%q name=%q) = %q, want %q",
+				tc.rule.ID, tc.rule.Name, got, tc.want)
 		}
 	}
 }

--- a/pkg/embedded/processors/simplecondition/config.go
+++ b/pkg/embedded/processors/simplecondition/config.go
@@ -1,6 +1,7 @@
 package simplecondition
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 )
@@ -38,6 +39,7 @@ const (
 	DataTypeString  DataType = "string"
 	DataTypeNumber  DataType = "number"
 	DataTypeBoolean DataType = "boolean"
+	DataTypeEvent   DataType = "event"
 )
 
 // LogicOperator defines how to combine multiple conditions.
@@ -60,6 +62,49 @@ type ManualInput struct {
 	Type     DataType           `json:"type"`     // string, number, or boolean
 	Value    string             `json:"value"`    // Expected value as string (will be converted based on Type)
 	Operator ComparisonOperator `json:"operator"` // Comparison operator
+}
+
+// UnmarshalJSON accepts legacy configs where "value" is a JSON string, boolean, number, or null.
+// Stored workflow JSON often uses native JSON types; ConvertValue still parses from string.
+func (m *ManualInput) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		Name     string             `json:"name"`
+		Type     DataType           `json:"type"`
+		Value    json.RawMessage    `json:"value"`
+		Operator ComparisonOperator `json:"operator"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	m.Name = aux.Name
+	m.Type = aux.Type
+	m.Operator = aux.Operator
+
+	if len(aux.Value) == 0 || string(aux.Value) == "null" {
+		m.Value = ""
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(aux.Value, &s); err == nil {
+		m.Value = s
+		return nil
+	}
+	var b bool
+	if err := json.Unmarshal(aux.Value, &b); err == nil {
+		if b {
+			m.Value = "true"
+		} else {
+			m.Value = "false"
+		}
+		return nil
+	}
+	var f float64
+	if err := json.Unmarshal(aux.Value, &f); err == nil {
+		m.Value = strconv.FormatFloat(f, 'f', -1, 64)
+		return nil
+	}
+	return fmt.Errorf("manual_inputs.value: unsupported JSON type: %s", string(aux.Value))
 }
 
 // Validate checks if the configuration is valid.
@@ -95,8 +140,8 @@ func (m *ManualInput) Validate() error {
 	if m.Type == "" {
 		return fmt.Errorf("type is required")
 	}
-	if m.Type != DataTypeString && m.Type != DataTypeNumber && m.Type != DataTypeBoolean {
-		return fmt.Errorf("invalid type '%s', must be 'string', 'number', or 'boolean'", m.Type)
+	if m.Type != DataTypeString && m.Type != DataTypeNumber && m.Type != DataTypeBoolean && m.Type != DataTypeEvent {
+		return fmt.Errorf("invalid type '%s', must be 'string', 'number', 'boolean', or 'event'", m.Type)
 	}
 	if m.Operator == "" {
 		return fmt.Errorf("operator is required")
@@ -146,7 +191,7 @@ func validateOperatorTypeCompatibility(operator ComparisonOperator, dataType Dat
 			return fmt.Errorf("operator '%s' is only supported for 'string' type, got '%s'", operator, dataType)
 		}
 	case OpIsEmpty, OpIsNotEmpty:
-		// Supported for string, number, boolean (value is ignored)
+		// Supported for string, number, boolean, event (value is ignored)
 		return nil
 	default:
 		return fmt.Errorf("unsupported operator '%s'", operator)
@@ -174,6 +219,16 @@ func (m *ManualInput) ConvertValue() (interface{}, error) {
 			return false, nil
 		default:
 			return nil, fmt.Errorf("cannot convert value '%s' to boolean (expected 'true' or 'false')", m.Value)
+		}
+	case DataTypeEvent:
+		// Treat "event" as boolean for comparison purposes.
+		switch m.Value {
+		case "true", "True", "TRUE", "1":
+			return true, nil
+		case "false", "False", "FALSE", "0":
+			return false, nil
+		default:
+			return nil, fmt.Errorf("cannot convert value '%s' to event (expected 'true' or 'false')", m.Value)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported type '%s'", m.Type)

--- a/pkg/embedded/processors/simplecondition/tests/config_test.go
+++ b/pkg/embedded/processors/simplecondition/tests/config_test.go
@@ -118,6 +118,7 @@ func TestIsEmptyIsNotEmptyOperators(t *testing.T) {
 		simplecondition.DataTypeString,
 		simplecondition.DataTypeNumber,
 		simplecondition.DataTypeBoolean,
+		simplecondition.DataTypeEvent,
 	}
 	for _, op := range emptyOps {
 		for _, typ := range types {

--- a/pkg/embedded/processors/simplecondition/tests/process_test.go
+++ b/pkg/embedded/processors/simplecondition/tests/process_test.go
@@ -160,3 +160,75 @@ func TestProcessMissingFieldWithIsEmptyNoWarning(t *testing.T) {
 		t.Errorf("expected output[\"true\"] when Is Empty and field missing")
 	}
 }
+
+// TestProcess_LegacyBooleanValueInRawConfig ensures RawConfig from stored workflows
+// (JSON boolean for manual_inputs.value) parses and routes like string "true".
+func TestProcess_LegacyBooleanValueInRawConfig(t *testing.T) {
+	node := createConditionNode(t, "test-condition-node")
+	raw := []byte(`{"logic_operator":"AND","manual_inputs":[{"name":"in","operator":"equals","type":"boolean","value":true}]}`)
+	input := createProcessInput(map[string]interface{}{"in": true}, raw)
+
+	output := node.Process(input)
+
+	if output.Error != nil {
+		t.Fatalf("expected no config error, got: %v", output.Error)
+	}
+	if output.Data["true"] == nil {
+		t.Fatalf("expected output[\"true\"] when in==true matches literal true")
+	}
+	if output.Data["false"] != nil {
+		t.Fatalf("expected output[\"false\"] nil, got %v", output.Data["false"])
+	}
+}
+
+// TestProcess_LegacyNumberValueInRawConfig ensures JSON number manual value unmarshals and compares.
+func TestProcess_LegacyNumberValueInRawConfig(t *testing.T) {
+	node := createConditionNode(t, "test-condition-node")
+	raw := []byte(`{"logic_operator":"AND","manual_inputs":[{"name":"n","operator":"equals","type":"number","value":42}]}`)
+	input := createProcessInput(map[string]interface{}{"n": float64(42)}, raw)
+
+	output := node.Process(input)
+
+	if output.Error != nil {
+		t.Fatalf("expected no config error, got: %v", output.Error)
+	}
+	if output.Data["true"] == nil {
+		t.Fatalf("expected output[\"true\"] when n==42")
+	}
+}
+
+func TestProcess_EventType_EqualsTrue_WhenFieldIsTrue(t *testing.T) {
+	node := createConditionNode(t, "test-condition-node")
+	raw := []byte(`{"logic_operator":"AND","manual_inputs":[{"name":"ev","operator":"equals","type":"event","value":true}]}`)
+	input := createProcessInput(map[string]interface{}{"ev": true}, raw)
+
+	output := node.Process(input)
+
+	if output.Error != nil {
+		t.Fatalf("expected no config error, got: %v", output.Error)
+	}
+	if output.Data["true"] == nil {
+		t.Fatalf("expected output[\"true\"] when ev==true and expected=true")
+	}
+	if output.Data["false"] != nil {
+		t.Fatalf("expected output[\"false\"] nil, got %v", output.Data["false"])
+	}
+}
+
+func TestProcess_EventType_IsEmpty_WhenFieldMissing(t *testing.T) {
+	node := createConditionNode(t, "test-condition-node")
+	raw := []byte(`{"logic_operator":"AND","manual_inputs":[{"name":"missing","operator":"is_empty","type":"event","value":null}]}`)
+	input := createProcessInput(map[string]interface{}{}, raw)
+
+	output := node.Process(input)
+
+	if output.Error != nil {
+		t.Fatalf("expected no error, got: %v", output.Error)
+	}
+	if _, hasWarning := output.Data["warning"]; hasWarning {
+		t.Fatalf("expected no warning for is_empty on missing event field, got %v", output.Data["warning"])
+	}
+	if output.Data["true"] == nil {
+		t.Fatalf("expected output[\"true\"] when is_empty and field missing")
+	}
+}

--- a/pkg/schema/hl7/header_validator.go
+++ b/pkg/schema/hl7/header_validator.go
@@ -14,19 +14,38 @@ import (
 func versionsMatch(a, b string) bool {
 	a = strings.TrimSpace(a)
 	b = strings.TrimSpace(b)
+	// Preserve the special case: both empty means "no version constraint".
+	if a == "" && b == "" {
+		return true
+	}
 	na := normalizeVersion(a)
 	nb := normalizeVersion(b)
+	// If either side normalizes to empty (e.g. nonsense like bare "v"), never match.
+	if na == "" || nb == "" {
+		return false
+	}
 	return strings.EqualFold(na, nb)
 }
 
 func normalizeVersion(v string) string {
 	v = strings.TrimSpace(v)
 	// Strip optional leading "v"/"V" only when followed by a digit (e.g. "v2.5.1", not bare "v").
-	if len(v) >= 2 && (v[0] == 'v' || v[0] == 'V') {
+	if len(v) >= 2 && (v[0] == 'v' || v[0] == 'V') && v[1] >= '0' && v[1] <= '9' {
 		v = v[1:]
 	}
 	for strings.HasSuffix(v, ".0") {
 		v = strings.TrimSuffix(v, ".0")
+	}
+	// Treat nonsense strings without any digit as empty (e.g. "v", "version").
+	hasDigit := false
+	for i := 0; i < len(v); i++ {
+		if v[i] >= '0' && v[i] <= '9' {
+			hasDigit = true
+			break
+		}
+	}
+	if !hasDigit {
+		return ""
 	}
 	return v
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -21,6 +21,9 @@ type integrationProcessor struct {
 }
 
 func (p *integrationProcessor) Process(ctx context.Context, msg *message.Message) (message.Message, error) {
+	if p == nil {
+		return message.Message{}, errors.New("integration processor is nil")
+	}
 	p.processedMessages = append(p.processedMessages, msg)
 
 	if p.shouldFail {


### PR DESCRIPTION
- Introduced 'DataTypeEvent' to support event type in manual inputs.
- Updated UnmarshalJSON method to handle legacy JSON configurations for boolean and number values.
- Enhanced validation logic to include 'event' type checks.
- Added unit tests to verify correct processing of legacy boolean and number values, as well as event type handling.
- Fix unit tests and hl7 header validator