### PR TITLE
Treat absent field mappings as optional during input resolution

### DIFF
--- a/pkg/resolver/fieldmapping_builder.go
+++ b/pkg/resolver/fieldmapping_builder.go
@@ -1179,15 +1179,11 @@ func buildInputFromMappings(params BuildInputParams) ([]byte, error) {
 		}
 
 		if sourceData == nil {
-			// Track the failure with available field keys
-			fieldKeys := []string{}
-			if sourceResult.ProjectedFields != nil {
-				if nodeFields, hasNode := sourceResult.ProjectedFields[mapping.SourceNodeID]; hasNode {
-					fieldKeys = getMapKeys(nodeFields)
-				}
-			}
-			failedMappings = append(failedMappings, fmt.Sprintf("failed to extract '%s' from source node '%s' (available fields: %v)",
-				mapping.SourceEndpoint, mapping.SourceNodeID, fieldKeys))
+			// The source field is absent from the upstream output — treat as an optional field
+			// and skip silently. The plugin will fall back to its nodeConfig defaults
+			// (e.g. an SFTP node whose path was not overridden will use its configured
+			// default path). Only structural failures (source node not found, non-success
+			// status) are recorded in failedMappings and cause a hard error.
 			continue
 		}
 
@@ -1286,17 +1282,17 @@ func buildInputFromMappings(params BuildInputParams) ([]byte, error) {
 	}
 
 	if len(inputData) == 0 {
-		// No field mappings succeeded - return detailed error instead of falling back to trigger data
 		if len(failedMappings) > 0 {
+			// Structural failures: source node not found or had a non-success status.
 			return nil, fmt.Errorf("field mapping resolution failed: no data could be extracted. Failures: %s",
 				strings.Join(failedMappings, "; "))
 		}
-		// No field mappings at all
-		if len(params.FieldMappings) == 0 {
-			return []byte("{}"), nil
-		}
-		// All mappings were event triggers
-		return nil, fmt.Errorf("field mapping resolution failed: no non-event-trigger field mappings were provided")
+		// inputData is empty but there are no structural failures. This happens when:
+		//   - all source fields were absent from upstream output (optional fields), or
+		//   - all mappings were event triggers, or
+		//   - there were no mappings at all.
+		// Return an empty object so the plugin can apply its nodeConfig defaults.
+		return []byte("{}"), nil
 	}
 
 	result, err := json.Marshal(inputData)

--- a/pkg/resolver/fieldmapping_builder_test.go
+++ b/pkg/resolver/fieldmapping_builder_test.go
@@ -5703,14 +5703,14 @@ func TestBuildInputFromMappings_EmptyDestinationEndpoints(t *testing.T) {
 	}
 
 	// Should NOT panic even though DestinationEndpoints is empty.
-	// The builder will return an error because no data could be extracted,
-	// but the critical thing is: no index-out-of-range panic.
-	_, err := buildInputFromMappings(params)
-	if err == nil {
-		t.Fatal("expected error for mapping with empty destinations, got nil")
+	// The mapping produces no output because there are no destinations to write to.
+	// The builder returns {} so that the plugin can fall back to its nodeConfig defaults.
+	result, err := buildInputFromMappings(params)
+	if err != nil {
+		t.Fatalf("expected no error for mapping with empty destinations, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "field mapping resolution failed") {
-		t.Errorf("expected field mapping resolution error, got: %v", err)
+	if string(result) != "{}" {
+		t.Errorf("expected '{}' for mapping with empty destinations, got: %s", string(result))
 	}
 }
 
@@ -5825,14 +5825,55 @@ func TestBuildInputFromMappings_AllEventTriggerMappings(t *testing.T) {
 		SourceResults: map[string]*SourceResult{},
 	}
 
-	// All mappings are event triggers, so no data can be extracted.
-	// The builder returns an error for this case.
-	_, err := buildInputFromMappings(params)
-	if err == nil {
-		t.Fatal("expected error for all-event-trigger mappings, got nil")
+	// All mappings are event triggers, so no field data is extracted.
+	// The builder returns {} so the plugin can fall back to its nodeConfig defaults.
+	result, err := buildInputFromMappings(params)
+	if err != nil {
+		t.Fatalf("expected no error for all-event-trigger mappings, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "no non-event-trigger") {
-		t.Errorf("expected 'no non-event-trigger' message, got: %v", err)
+	if string(result) != "{}" {
+		t.Errorf("expected '{}' for all-event-trigger mappings, got: %s", string(result))
+	}
+}
+
+// TestBuildInputFromMappings_NilSourceFieldReturnsEmptyObject verifies that when
+// the upstream output does not contain the field referenced by a field mapping,
+// the builder returns {} instead of an error so that the plugin can fall back to
+// its nodeConfig defaults.
+//
+// Scenario: SFTP List Files is configured with path "/" in its nodeConfig. The
+// trigger fires with no path field. An embedded JSON Parser receives the trigger
+// payload and produces output with no "/path" key. The SFTP field mapping
+// references "/path" from the JSON Parser, which is absent. The builder must
+// return {} — not an error — so the SFTP activity can use its "/"  default.
+func TestBuildInputFromMappings_NilSourceFieldReturnsEmptyObject(t *testing.T) {
+	// JSON Parser produced output with no "/path" key.
+	params := BuildInputParams{
+		FieldMappings: []message.FieldMapping{
+			{
+				SourceNodeID:         "json-parser-node",
+				SourceEndpoint:       "/path",
+				DestinationEndpoints: []string{"/path"},
+			},
+		},
+		SourceResults: map[string]*SourceResult{
+			"json-parser-node": {
+				NodeID: "json-parser-node",
+				Status: "success",
+				ProjectedFields: map[string]map[string]interface{}{
+					// JSON Parser ran successfully but produced no "path" field.
+					"json-parser-node": {"data": map[string]interface{}{"foo": "bar"}},
+				},
+			},
+		},
+	}
+
+	result, err := buildInputFromMappings(params)
+	if err != nil {
+		t.Fatalf("expected no error when source field is absent, got: %v", err)
+	}
+	if string(result) != "{}" {
+		t.Errorf("expected '{}' when source field is absent, got: %s", string(result))
 	}
 }
 


### PR DESCRIPTION
When a mapped source field is missing from upstream output, skip that mapping instead of failing resolution. If no mapped fields are present and there are no structural failures, return {} so plugins can fall back to nodeConfig defaults (for example, SFTP list files using a configured path when the trigger omits path).
Keep hard errors for structural failures such as a missing source node or a non-success source status. Update resolver tests and add coverage for absent mapped fields.