### PR TITLE
fix: synthesize error:false for pluginError consumers on success

### DIFF
--- a/README.md
+++ b/README.md
@@ -1518,6 +1518,10 @@ When neither `message` nor `default_error_message` is set, the runtime uses a de
   - a **field mapping** (e.g. `/errorDescription` as a `FIELD` into a handler node).
 - If at least one such mapping exists, the embedded runtime treats the error as **handled** and does not fail-fast; if no mappings from `pluginError` exist, the error bubbles up and causes the embedded unit / workflow run to fail, making this node useful for hard-stop guards as well as structured error flows.
 
+**Success-path guarantee for `pluginError` consumers:**
+
+Any node that maps from another node's `pluginError` section receives `error = false` and `errorDescription = ""` when that source node **succeeded**, regardless of whether the source is the parent unit, an embedded sibling in the same unit, or a node from a prior unit. The runtime synthesises these defaults at input-resolution time so that a downstream condition checking `error equals false` evaluates correctly without the source node having to include those keys in its own output payload.
+
 ## String Processing Utilities
 
 The SDK includes comprehensive string processing utilities for workflow orchestration and data manipulation:

--- a/pkg/embedded/runtime/event_data_passthrough_test.go
+++ b/pkg/embedded/runtime/event_data_passthrough_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"testing"
 )
 
@@ -107,4 +108,304 @@ func TestWithImplicitNoErrorDefaults_NilInput(t *testing.T) {
 	if v, _ := out[ErrorOutputKeyError].(bool); v {
 		t.Errorf("expected error=false on nil input; got %#v", out[ErrorOutputKeyError])
 	}
+}
+
+// --- buildSingleNodeInput pluginError enrichment tests ---
+//
+// These tests cover the three scenarios where a node's output is stored without
+// an "error" key and a downstream embedded node reads from its pluginError section:
+//
+//   Scenario 2: embedded sibling (intra-unit, non-iteration)
+//   Scenario 3: embedded sibling (intra-unit, iteration) — see buildItemInput tests
+//   Scenario 4: prior-unit node (cross-unit, seeded via priorUnitOutputs)
+//
+// Scenario 1 (parent → embedded) already works because processSingleObject enriches
+// the parent output before seeding the store.
+
+// TestBuildSingleNodeInput_PluginError_EmbeddedSiblingSuccess verifies that when an
+// embedded sibling succeeds with no "error" key in its output (e.g. JSON Producer
+// returning {"encoded": "..."}), a downstream node that maps from the sibling's
+// pluginError /error section receives error=false rather than an empty input map.
+// This is scenario 2 (intra-unit embedded → embedded, non-iteration).
+func TestBuildSingleNodeInput_PluginError_EmbeddedSiblingSuccess(t *testing.T) {
+	const siblingNodeID = "sibling-node"
+	const consumerNodeID = "consumer-node"
+
+	sp := &SubflowProcessor{
+		parentNodeId: "parent-node",
+		logger:       &NoOpLogger{},
+	}
+
+	store := NewNodeOutputStore()
+	store.SetSingleOutput(siblingNodeID, map[string]interface{}{"encoded": "abc"})
+
+	consumerCfg := EmbeddedNodeConfig{
+		NodeId: consumerNodeID,
+		FieldMappings: []FieldMapping{
+			{
+				SourceNodeId:         siblingNodeID,
+				SourceEndpoint:       "/error",
+				SourceSectionId:      SectionPluginError,
+				DestinationEndpoints: []string{"/error"},
+				DataType:             "EVENT",
+			},
+		},
+	}
+
+	input := sp.buildSingleNodeInput(consumerCfg, store)
+
+	errVal, ok := input[ErrorOutputKeyError]
+	if !ok {
+		t.Fatalf("expected 'error' key in consumer input; got %v", input)
+	}
+	if v, _ := errVal.(bool); v {
+		t.Errorf("expected error=false (sibling succeeded); got %v", errVal)
+	}
+}
+
+// TestBuildSingleNodeInput_PluginError_EmbeddedSiblingError verifies that when an
+// embedded sibling fails and stores {error: true, errorDescription: "boom"}, a
+// downstream pluginError consumer receives the real error values unmodified.
+// This is the regression guard — failure payloads must not be overwritten.
+func TestBuildSingleNodeInput_PluginError_EmbeddedSiblingError(t *testing.T) {
+	const siblingNodeID = "sibling-node"
+	const consumerNodeID = "consumer-node"
+
+	sp := &SubflowProcessor{
+		parentNodeId: "parent-node",
+		logger:       &NoOpLogger{},
+	}
+
+	store := NewNodeOutputStore()
+	store.SetSingleOutput(siblingNodeID, map[string]interface{}{
+		ErrorOutputKeyError:       true,
+		ErrorOutputKeyDescription: "boom",
+	})
+
+	consumerCfg := EmbeddedNodeConfig{
+		NodeId: consumerNodeID,
+		FieldMappings: []FieldMapping{
+			{
+				SourceNodeId:         siblingNodeID,
+				SourceEndpoint:       "/error",
+				SourceSectionId:      SectionPluginError,
+				DestinationEndpoints: []string{"/error"},
+				DataType:             "EVENT",
+			},
+			{
+				SourceNodeId:         siblingNodeID,
+				SourceEndpoint:       "/errorDescription",
+				SourceSectionId:      SectionPluginError,
+				DestinationEndpoints: []string{"/errorDescription"},
+				DataType:             "FIELD",
+			},
+		},
+	}
+
+	input := sp.buildSingleNodeInput(consumerCfg, store)
+
+	if v, _ := input[ErrorOutputKeyError].(bool); !v {
+		t.Errorf("expected error=true preserved from failure payload; got %v", input[ErrorOutputKeyError])
+	}
+	if v, _ := input[ErrorOutputKeyDescription].(string); v != "boom" {
+		t.Errorf("expected errorDescription='boom' preserved; got %v", input[ErrorOutputKeyDescription])
+	}
+}
+
+// TestBuildSingleNodeInput_PluginError_PriorUnitEmbedded verifies the cross-unit
+// scenario (scenario 4): a prior unit's embedded node output is seeded into the store
+// via priorUnitOutputs with no "error" key, and a current-unit consumer that maps
+// from its pluginError /error receives error=false.
+func TestBuildSingleNodeInput_PluginError_PriorUnitEmbedded(t *testing.T) {
+	const priorEmbeddedNodeID = "prior-unit-json-producer"
+	const consumerNodeID = "consumer-node"
+
+	sp := &SubflowProcessor{
+		parentNodeId: "parent-node",
+		logger:       &NoOpLogger{},
+	}
+
+	// Simulate how ProcessItem seeds priorUnitOutputs into the store raw (no enrichment
+	// at write time — the gap this fix closes at read time).
+	store := NewNodeOutputStore()
+	store.SetSingleOutput(priorEmbeddedNodeID, map[string]interface{}{"encoded": "xyz"})
+
+	consumerCfg := EmbeddedNodeConfig{
+		NodeId: consumerNodeID,
+		FieldMappings: []FieldMapping{
+			{
+				SourceNodeId:         priorEmbeddedNodeID,
+				SourceEndpoint:       "/error",
+				SourceSectionId:      SectionPluginError,
+				DestinationEndpoints: []string{"/error"},
+				DataType:             "EVENT",
+			},
+		},
+	}
+
+	input := sp.buildSingleNodeInput(consumerCfg, store)
+
+	errVal, ok := input[ErrorOutputKeyError]
+	if !ok {
+		t.Fatalf("expected 'error' key in consumer input for cross-unit scenario; got %v", input)
+	}
+	if v, _ := errVal.(bool); v {
+		t.Errorf("expected error=false (prior-unit node succeeded); got %v", errVal)
+	}
+}
+
+// --- buildItemInput pluginError enrichment test ---
+
+// TestBuildItemInput_PluginError_EmbeddedSiblingSuccess verifies scenario 3: when
+// processing an iteration item, a consumer that maps from a sibling's pluginError
+// /error section via the itemStore path receives error=false on success.
+func TestBuildItemInput_PluginError_EmbeddedSiblingSuccess(t *testing.T) {
+	const iterSourceNodeID = "iter-source"
+	const siblingNodeID = "sibling-node"
+	const consumerNodeID = "consumer-node"
+
+	sp := &SubflowProcessor{
+		parentNodeId: "parent-node",
+		logger:       &NoOpLogger{},
+	}
+
+	// itemStore holds outputs of nodes already executed for this iteration item.
+	// The sibling succeeded with no "error" key — this is what triggers the bug.
+	itemStore := NewNodeOutputStore()
+	itemStore.SetSingleOutput(siblingNodeID, map[string]interface{}{"encoded": "abc"})
+
+	// The iteration source is a different node; this forces the else-if branch in
+	// buildItemInput (SourceNodeId != iter.SourceNodeId).
+	iter := IterationState{
+		IsActive:     true,
+		SourceNodeId: iterSourceNodeID,
+		ArrayPath:    "items",
+		TotalItems:   1,
+		Items:        []interface{}{map[string]interface{}{"val": "x"}},
+	}
+
+	consumerCfg := EmbeddedNodeConfig{
+		NodeId: consumerNodeID,
+		FieldMappings: []FieldMapping{
+			{
+				SourceNodeId:         siblingNodeID,
+				SourceEndpoint:       "/error",
+				SourceSectionId:      SectionPluginError,
+				DestinationEndpoints: []string{"/error"},
+				DataType:             "EVENT",
+			},
+		},
+	}
+
+	input, shouldSkip := sp.buildItemInput(consumerCfg, itemStore, iter, 0)
+
+	if shouldSkip {
+		t.Fatal("expected shouldSkip=false; no mappings required deeper iteration")
+	}
+	errVal, ok := input[ErrorOutputKeyError]
+	if !ok {
+		t.Fatalf("expected 'error' key in consumer input (iteration path); got %v", input)
+	}
+	if v, _ := errVal.(bool); v {
+		t.Errorf("expected error=false (sibling succeeded, iteration path); got %v", errVal)
+	}
+}
+
+// --- end-to-end integration: pluginError consumer via SubflowProcessor.ProcessItem ---
+
+// TestProcessItem_PluginError_EmbeddedSiblingSuccess runs a two-node embedded chain
+// through the full SubflowProcessor.ProcessItem path: a "producer" node that emits
+// only {"encoded": "abc"} (no error key), followed by a SimpleCondition-like
+// "consumer" node that reads /error from the producer's pluginError section.
+// Before the fix the consumer received empty input and emitted a warning.
+// After the fix it should receive error=false.
+func TestProcessItem_PluginError_EmbeddedSiblingSuccess(t *testing.T) {
+	const parentNodeID = "parent"
+	const producerNodeID = "producer"
+	const consumerNodeID = "consumer"
+
+	capturedInputs := make(map[string]map[string]interface{})
+
+	// producer: always returns {"encoded": "abc"} (simulates a successful JSON Producer).
+	producerCfg := EmbeddedNodeConfig{
+		NodeId:         producerNodeID,
+		Label:          "producer",
+		PluginType:     "plugin-stub-producer",
+		Embeddable:     true,
+		Depth:          0,
+		ExecutionOrder: 1,
+		FieldMappings:  []FieldMapping{},
+		NodeConfig:     NodeConfig{NodeId: producerNodeID},
+	}
+	// consumer: reads /error from producer's pluginError section, stores in /gotError.
+	consumerCfg := EmbeddedNodeConfig{
+		NodeId:         consumerNodeID,
+		Label:          "consumer",
+		PluginType:     "plugin-stub-consumer",
+		Embeddable:     true,
+		Depth:          1,
+		ExecutionOrder: 2,
+		FieldMappings: []FieldMapping{
+			{
+				SourceNodeId:         producerNodeID,
+				SourceEndpoint:       "/error",
+				SourceSectionId:      SectionPluginError,
+				DestinationEndpoints: []string{"/gotError"},
+				DataType:             "EVENT",
+			},
+		},
+		NodeConfig: NodeConfig{NodeId: consumerNodeID},
+	}
+
+	factory := NewDefaultNodeFactory()
+	factory.Register("plugin-stub-producer", func(cfg EmbeddedNodeConfig) (EmbeddedNode, error) {
+		return &stubNode{nodeID: cfg.NodeId, pluginType: cfg.PluginType, output: map[string]interface{}{"encoded": "abc"}, captured: capturedInputs}, nil
+	})
+	factory.Register("plugin-stub-consumer", func(cfg EmbeddedNodeConfig) (EmbeddedNode, error) {
+		return &stubNode{nodeID: cfg.NodeId, pluginType: cfg.PluginType, output: map[string]interface{}{"result": "ok"}, captured: capturedInputs}, nil
+	})
+
+	sp, err := NewSubflowProcessor(SubflowConfig{
+		ParentNodeId: parentNodeID,
+		NodeConfigs:  []EmbeddedNodeConfig{producerCfg, consumerCfg},
+		Factory:      factory,
+	})
+	if err != nil {
+		t.Fatalf("NewSubflowProcessor: %v", err)
+	}
+
+	parentOutput := map[string]interface{}{"payload": "data"}
+	result := sp.ProcessItem(context.Background(), BatchItem{Index: 0, Data: parentOutput})
+	if result.Error != nil {
+		t.Fatalf("ProcessItem failed: %v", result.Error)
+	}
+
+	gotError, ok := capturedInputs[consumerNodeID]["gotError"]
+	if !ok {
+		t.Fatalf("consumer did not receive 'gotError' in input; got %v", capturedInputs[consumerNodeID])
+	}
+	if v, _ := gotError.(bool); v {
+		t.Errorf("expected consumer gotError=false (producer succeeded); got %v", gotError)
+	}
+}
+
+// stubNode is a minimal EmbeddedNode implementation for tests.
+// It records the input it receives and returns a pre-configured output.
+type stubNode struct {
+	nodeID     string
+	pluginType string
+	output     map[string]interface{}
+	captured   map[string]map[string]interface{}
+}
+
+func (n *stubNode) NodeId() string     { return n.nodeID }
+func (n *stubNode) PluginType() string { return n.pluginType }
+
+func (n *stubNode) Process(input ProcessInput) ProcessOutput {
+	snapshot := make(map[string]interface{}, len(input.Data))
+	for k, v := range input.Data {
+		snapshot[k] = v
+	}
+	n.captured[n.nodeID] = snapshot
+	return SuccessOutput(n.output)
 }

--- a/pkg/embedded/runtime/subflow.go
+++ b/pkg/embedded/runtime/subflow.go
@@ -1627,12 +1627,17 @@ func (sp *SubflowProcessor) buildItemInput(
 			if m.SourceSectionId == SectionDefault && IsErrorOnlyOutput(sourceOut) {
 				continue
 			}
+			// Same pluginError success-path enrichment as buildSingleNodeInput.
+			effectiveOut := sourceOut
+			if m.SourceSectionId == SectionPluginError && !IsErrorOnlyOutput(sourceOut) {
+				effectiveOut = withImplicitNoErrorDefaults(sourceOut)
+			}
 			if strings.Contains(m.SourceEndpoint, "//") {
 				// Parse the nested path and extract value considering current context
-				val = sp.extractNestedValueFromSource(sourceOut, m.SourceEndpoint, itemStore, itemIndex)
+				val = sp.extractNestedValueFromSource(effectiveOut, m.SourceEndpoint, itemStore, itemIndex)
 			} else {
 				// Simple path extraction
-				val = sp.extractValue(sourceOut, m.SourceEndpoint)
+				val = sp.extractValue(effectiveOut, m.SourceEndpoint)
 			}
 		}
 
@@ -1900,12 +1905,20 @@ func (sp *SubflowProcessor) buildSingleNodeInput(
 			continue
 		}
 
+		// When reading from a pluginError section on the success path, synthesise the implicit
+		// error:false / errorDescription:"" defaults that the source node never stores itself.
+		// IsErrorOnlyOutput guards the failure path so real error values are never overwritten.
+		effectiveOut := sourceOut
+		if m.SourceSectionId == SectionPluginError && !IsErrorOnlyOutput(sourceOut) {
+			effectiveOut = withImplicitNoErrorDefaults(sourceOut)
+		}
+
 		// Normalize source endpoint: //field -> /$items//field for root-array access
 		normalizedEndpoint := NormalizeRootArrayEndpoint(m.SourceEndpoint)
 
 		// Check for root-as-array with empty sourceEndpoint (pass-through case)
 		if m.SourceEndpoint == "" {
-			if items, ok := sourceOut[RootArrayKey]; ok {
+			if items, ok := effectiveOut[RootArrayKey]; ok {
 				// Pass the raw array directly to destination endpoints
 				for _, dest := range m.DestinationEndpoints {
 					if dest == "" {
@@ -1918,7 +1931,7 @@ func (sp *SubflowProcessor) buildSingleNodeInput(
 			}
 		}
 
-		val := sp.extractValue(sourceOut, normalizedEndpoint)
+		val := sp.extractValue(effectiveOut, normalizedEndpoint)
 		if val == nil {
 			continue
 		}


### PR DESCRIPTION
Embedded nodes that map from another node's pluginError section (e.g. Simple Condition checking error equals false after JSON Producer) previously received empty input when the source succeeded, because success outputs only carry payload fields like encoded and never include error keys.

Apply withImplicitNoErrorDefaults at read time in buildSingleNodeInput and buildItemInput when sourceSectionId is pluginError and the source is not error-only. This covers parent→embedded, embedded→embedded, and prior-unit→ embedded consumers without mutating stored node outputs. Failure paths still expose error:true and errorDescription unchanged.

Adds regression tests and documents the success-path guarantee in README.