### PR TITLE
feat: add Constant Value Generator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1522,6 +1522,23 @@ When neither `message` nor `default_error_message` is set, the runtime uses a de
 
 Any node that maps from another node's `pluginError` section receives `error = false` and `errorDescription = ""` when that source node **succeeded**, regardless of whether the source is the parent unit, an embedded sibling in the same unit, or a node from a prior unit. The runtime synthesises these defaults at input-resolution time so that a downstream condition checking `error equals false` evaluates correctly without the source node having to include those keys in its own output payload.
 
+### Constant Value Generator (`plugin-constant-value-generator`)
+
+The Constant Value Generator is a source-style embedded node that emits a fixed set of typed values without requiring any input.
+
+**Configuration:**
+
+- **label**: Display name for the node (from the Apollo node schema).
+- **constants**: Array of `{ name, type, value }` entries. Each entry becomes an output port keyed by `name`.
+  - **type**: `string`, `number`, or `boolean`.
+  - **value**: Literal value (stored as text in the schema; native JSON bool/number are accepted when unmarshalling).
+
+**Behavior:**
+
+- Ignores `ProcessInput.Data`; the node has no input fields.
+- On success, returns `ProcessOutput.Data` with one key per constant `name` and the value cast to the appropriate Go type (`string`, `float64`, or `bool`).
+- Registered in `pkg/embedded/processors/registry.go` via `constantvalue.NewConstantValueNode`.
+
 ## String Processing Utilities
 
 The SDK includes comprehensive string processing utilities for workflow orchestration and data manipulation:

--- a/pkg/embedded/processors/constantvalue/config.go
+++ b/pkg/embedded/processors/constantvalue/config.go
@@ -1,0 +1,130 @@
+package constantvalue
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// DataType specifies how to interpret constant values.
+type DataType string
+
+const (
+	DataTypeString  DataType = "string"
+	DataTypeNumber  DataType = "number"
+	DataTypeBoolean DataType = "boolean"
+)
+
+// Config defines the configuration for the constant value generator processor.
+type Config struct {
+	Constants []ConstantEntry `json:"constants"`
+}
+
+// ConstantEntry defines a single constant output field.
+type ConstantEntry struct {
+	Name  string   `json:"name"`
+	Type  DataType `json:"type"`
+	Value string   `json:"value"`
+}
+
+// UnmarshalJSON accepts configs where "value" is a JSON string, boolean, number, or null.
+func (c *ConstantEntry) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		Name  string          `json:"name"`
+		Type  DataType        `json:"type"`
+		Value json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	c.Name = aux.Name
+	c.Type = aux.Type
+
+	if len(aux.Value) == 0 || string(aux.Value) == "null" {
+		c.Value = ""
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(aux.Value, &s); err == nil {
+		c.Value = s
+		return nil
+	}
+	var b bool
+	if err := json.Unmarshal(aux.Value, &b); err == nil {
+		if b {
+			c.Value = "true"
+		} else {
+			c.Value = "false"
+		}
+		return nil
+	}
+	var f float64
+	if err := json.Unmarshal(aux.Value, &f); err == nil {
+		c.Value = strconv.FormatFloat(f, 'f', -1, 64)
+		return nil
+	}
+	return fmt.Errorf("constants.value: unsupported JSON type: %s", string(aux.Value))
+}
+
+// Validate checks if the configuration is valid.
+func (c *Config) Validate() error {
+	if len(c.Constants) == 0 {
+		return fmt.Errorf("at least one constant must be specified")
+	}
+
+	names := make(map[string]bool)
+	for i, entry := range c.Constants {
+		if err := entry.Validate(); err != nil {
+			return fmt.Errorf("constant at index %d: %w", i, err)
+		}
+		if names[entry.Name] {
+			return fmt.Errorf("duplicate constant name '%s'", entry.Name)
+		}
+		names[entry.Name] = true
+
+		if _, err := entry.CastValue(); err != nil {
+			return fmt.Errorf("constant '%s': %w", entry.Name, err)
+		}
+	}
+	return nil
+}
+
+// Validate checks if a constant entry is valid.
+func (e *ConstantEntry) Validate() error {
+	if e.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if e.Type == "" {
+		return fmt.Errorf("type is required")
+	}
+	if e.Type != DataTypeString && e.Type != DataTypeNumber && e.Type != DataTypeBoolean {
+		return fmt.Errorf("invalid type '%s', must be 'string', 'number', or 'boolean'", e.Type)
+	}
+	return nil
+}
+
+// CastValue converts the string value to the appropriate Go type based on DataType.
+func (e *ConstantEntry) CastValue() (interface{}, error) {
+	switch e.Type {
+	case DataTypeString:
+		return e.Value, nil
+	case DataTypeNumber:
+		result, err := strconv.ParseFloat(e.Value, 64)
+		if err != nil {
+			return nil, fmt.Errorf("cannot convert value '%s' to number: %w", e.Value, err)
+		}
+		return result, nil
+	case DataTypeBoolean:
+		switch e.Value {
+		case "true", "True", "TRUE", "1":
+			return true, nil
+		case "false", "False", "FALSE", "0":
+			return false, nil
+		default:
+			return nil, fmt.Errorf("cannot convert value '%s' to boolean (expected 'true' or 'false')", e.Value)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported type '%s'", e.Type)
+	}
+}

--- a/pkg/embedded/processors/constantvalue/constantvalue.go
+++ b/pkg/embedded/processors/constantvalue/constantvalue.go
@@ -1,0 +1,49 @@
+package constantvalue
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/wehubfusion/Icarus/pkg/embedded/runtime"
+)
+
+const pluginType = "plugin-constant-value-generator"
+
+// ConstantValueNode produces a fixed set of typed constant values as output fields.
+type ConstantValueNode struct {
+	runtime.BaseNode
+}
+
+// NewConstantValueNode creates a new constant value generator node.
+func NewConstantValueNode(config runtime.EmbeddedNodeConfig) (runtime.EmbeddedNode, error) {
+	if config.PluginType != pluginType {
+		return nil, fmt.Errorf("invalid plugin type: expected '%s', got '%s'", pluginType, config.PluginType)
+	}
+	return &ConstantValueNode{
+		BaseNode: runtime.NewBaseNode(config),
+	}, nil
+}
+
+// Process emits each configured constant as an output field keyed by name.
+// Input data is ignored; this node has no inputs.
+func (n *ConstantValueNode) Process(input runtime.ProcessInput) runtime.ProcessOutput {
+	var cfg Config
+	if err := json.Unmarshal(input.RawConfig, &cfg); err != nil {
+		return runtime.ErrorOutput(NewConfigError(n.NodeId(), "configuration", fmt.Sprintf("failed to parse configuration: %v", err)))
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return runtime.ErrorOutput(NewConfigError(n.NodeId(), "configuration", fmt.Sprintf("invalid configuration: %v", err)))
+	}
+
+	output := make(map[string]interface{}, len(cfg.Constants))
+	for _, entry := range cfg.Constants {
+		val, err := entry.CastValue()
+		if err != nil {
+			return runtime.ErrorOutput(NewConfigError(n.NodeId(), entry.Name, err.Error()))
+		}
+		output[entry.Name] = val
+	}
+
+	return runtime.SuccessOutput(output)
+}

--- a/pkg/embedded/processors/constantvalue/errors.go
+++ b/pkg/embedded/processors/constantvalue/errors.go
@@ -1,0 +1,23 @@
+package constantvalue
+
+import "fmt"
+
+// ConfigError represents a configuration validation error.
+type ConfigError struct {
+	NodeID  string
+	Field   string
+	Message string
+}
+
+func (e *ConfigError) Error() string {
+	return fmt.Sprintf("node %s: config error [%s]: %s", e.NodeID, e.Field, e.Message)
+}
+
+// NewConfigError creates a new ConfigError.
+func NewConfigError(nodeID, field, message string) *ConfigError {
+	return &ConfigError{
+		NodeID:  nodeID,
+		Field:   field,
+		Message: message,
+	}
+}

--- a/pkg/embedded/processors/constantvalue/tests/config_test.go
+++ b/pkg/embedded/processors/constantvalue/tests/config_test.go
@@ -1,0 +1,122 @@
+package tests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/wehubfusion/Icarus/pkg/embedded/processors/constantvalue"
+)
+
+func TestConfigValidateEmptyConstants(t *testing.T) {
+	cfg := constantvalue.Config{}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for empty constants list")
+	}
+}
+
+func TestConfigValidateDuplicateNames(t *testing.T) {
+	cfg := constantvalue.Config{
+		Constants: []constantvalue.ConstantEntry{
+			{Name: "dup", Type: constantvalue.DataTypeString, Value: "a"},
+			{Name: "dup", Type: constantvalue.DataTypeString, Value: "b"},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for duplicate constant names")
+	}
+}
+
+func TestConstantEntryValidateErrors(t *testing.T) {
+	cases := []constantvalue.ConstantEntry{
+		{},
+		{Name: "", Type: constantvalue.DataTypeString, Value: "x"},
+		{Name: "c", Type: "", Value: "x"},
+		{Name: "c", Type: "invalid", Value: "x"},
+	}
+	for i, entry := range cases {
+		if err := entry.Validate(); err == nil {
+			t.Fatalf("expected validation error for case %d", i)
+		}
+	}
+}
+
+func TestCastValue(t *testing.T) {
+	stringEntry := constantvalue.ConstantEntry{
+		Name:  "s",
+		Type:  constantvalue.DataTypeString,
+		Value: "hello",
+	}
+	val, err := stringEntry.CastValue()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "hello" {
+		t.Fatalf("expected 'hello', got %v", val)
+	}
+
+	numberEntry := constantvalue.ConstantEntry{
+		Name:  "n",
+		Type:  constantvalue.DataTypeNumber,
+		Value: "42.5",
+	}
+	val, err = numberEntry.CastValue()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f, ok := val.(float64); !ok || f != 42.5 {
+		t.Fatalf("expected 42.5, got %v", val)
+	}
+
+	boolEntry := constantvalue.ConstantEntry{
+		Name:  "b",
+		Type:  constantvalue.DataTypeBoolean,
+		Value: "true",
+	}
+	val, err = boolEntry.CastValue()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b, ok := val.(bool); !ok || !b {
+		t.Fatalf("expected true, got %v", val)
+	}
+
+	numberEntry.Value = "not a number"
+	if _, err := numberEntry.CastValue(); err == nil {
+		t.Fatal("expected error for invalid number")
+	}
+
+	boolEntry.Value = "maybe"
+	if _, err := boolEntry.CastValue(); err == nil {
+		t.Fatal("expected error for invalid boolean")
+	}
+}
+
+func TestConstantEntryUnmarshalJSONNativeTypes(t *testing.T) {
+	raw := `{"name":"flag","type":"boolean","value":true}`
+	var entry constantvalue.ConstantEntry
+	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if entry.Value != "true" {
+		t.Fatalf("expected value 'true', got %q", entry.Value)
+	}
+	val, err := entry.CastValue()
+	if err != nil {
+		t.Fatalf("CastValue failed: %v", err)
+	}
+	if b, ok := val.(bool); !ok || !b {
+		t.Fatalf("expected true, got %v", val)
+	}
+
+	raw = `{"name":"count","type":"number","value":99}`
+	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	val, err = entry.CastValue()
+	if err != nil {
+		t.Fatalf("CastValue failed: %v", err)
+	}
+	if f, ok := val.(float64); !ok || f != 99 {
+		t.Fatalf("expected 99, got %v", val)
+	}
+}

--- a/pkg/embedded/processors/constantvalue/tests/constantvalue_test.go
+++ b/pkg/embedded/processors/constantvalue/tests/constantvalue_test.go
@@ -1,0 +1,133 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/wehubfusion/Icarus/pkg/embedded/processors/constantvalue"
+	"github.com/wehubfusion/Icarus/pkg/embedded/runtime"
+)
+
+func createConstantValueNode(t *testing.T, nodeID string) *constantvalue.ConstantValueNode {
+	t.Helper()
+	cfg := runtime.EmbeddedNodeConfig{
+		NodeId:     nodeID,
+		Label:      "test-constant-value",
+		PluginType: "plugin-constant-value-generator",
+		Embeddable: true,
+		Depth:      0,
+		NodeConfig: runtime.NodeConfig{NodeId: nodeID},
+	}
+	node, err := constantvalue.NewConstantValueNode(cfg)
+	if err != nil {
+		t.Fatalf("failed to create ConstantValueNode: %v", err)
+	}
+	return node.(*constantvalue.ConstantValueNode)
+}
+
+func createProcessInput(nodeID string, rawConfig json.RawMessage) runtime.ProcessInput {
+	return runtime.ProcessInput{
+		Ctx:        context.Background(),
+		Data:       map[string]interface{}{"ignored": "input"},
+		RawConfig:  rawConfig,
+		NodeId:     nodeID,
+		PluginType: "plugin-constant-value-generator",
+		Label:      "test-constant-value",
+		ItemIndex:  -1,
+	}
+}
+
+func TestNewConstantValueNode_InvalidPluginType(t *testing.T) {
+	cfg := runtime.EmbeddedNodeConfig{
+		NodeId:     "node-1",
+		Label:      "test",
+		PluginType: "plugin-not-constant",
+	}
+	if _, err := constantvalue.NewConstantValueNode(cfg); err == nil {
+		t.Fatal("expected error for invalid plugin type")
+	}
+}
+
+func TestProcess_EmitsTypedConstants(t *testing.T) {
+	node := createConstantValueNode(t, "node-constants")
+
+	cfg := constantvalue.Config{
+		Constants: []constantvalue.ConstantEntry{
+			{Name: "greeting", Type: constantvalue.DataTypeString, Value: "hello"},
+			{Name: "count", Type: constantvalue.DataTypeNumber, Value: "42"},
+			{Name: "enabled", Type: constantvalue.DataTypeBoolean, Value: "true"},
+		},
+	}
+	rawCfg, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+
+	out := node.Process(createProcessInput("node-constants", rawCfg))
+	if out.Error != nil {
+		t.Fatalf("expected success, got error: %v", out.Error)
+	}
+	if out.Skipped {
+		t.Fatal("expected not skipped")
+	}
+
+	if out.Data["greeting"] != "hello" {
+		t.Errorf("greeting: got %v, want hello", out.Data["greeting"])
+	}
+	if f, ok := out.Data["count"].(float64); !ok || f != 42 {
+		t.Errorf("count: got %v, want 42", out.Data["count"])
+	}
+	if b, ok := out.Data["enabled"].(bool); !ok || !b {
+		t.Errorf("enabled: got %v, want true", out.Data["enabled"])
+	}
+}
+
+func TestProcess_InvalidConfigJSON(t *testing.T) {
+	node := createConstantValueNode(t, "node-invalid-json")
+	out := node.Process(createProcessInput("node-invalid-json", json.RawMessage(`{invalid`)))
+	if out.Error == nil {
+		t.Fatal("expected error for invalid config JSON")
+	}
+	if !strings.Contains(out.Error.Error(), "failed to parse configuration") {
+		t.Errorf("unexpected error: %v", out.Error)
+	}
+}
+
+func TestProcess_EmptyConstants(t *testing.T) {
+	node := createConstantValueNode(t, "node-empty")
+	rawCfg, _ := json.Marshal(constantvalue.Config{Constants: []constantvalue.ConstantEntry{}})
+	out := node.Process(createProcessInput("node-empty", rawCfg))
+	if out.Error == nil {
+		t.Fatal("expected error for empty constants")
+	}
+}
+
+func TestProcess_EmptyName(t *testing.T) {
+	node := createConstantValueNode(t, "node-empty-name")
+	cfg := constantvalue.Config{
+		Constants: []constantvalue.ConstantEntry{
+			{Name: "", Type: constantvalue.DataTypeString, Value: "x"},
+		},
+	}
+	rawCfg, _ := json.Marshal(cfg)
+	out := node.Process(createProcessInput("node-empty-name", rawCfg))
+	if out.Error == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestProcess_InvalidType(t *testing.T) {
+	node := createConstantValueNode(t, "node-bad-type")
+	cfg := constantvalue.Config{
+		Constants: []constantvalue.ConstantEntry{
+			{Name: "bad", Type: "unknown", Value: "x"},
+		},
+	}
+	rawCfg, _ := json.Marshal(cfg)
+	out := node.Process(createProcessInput("node-bad-type", rawCfg))
+	if out.Error == nil {
+		t.Fatal("expected error for invalid type")
+	}
+}

--- a/pkg/embedded/processors/jsonops/config.go
+++ b/pkg/embedded/processors/jsonops/config.go
@@ -17,8 +17,9 @@ type Config struct {
 	// Schema is the Icarus schema definition (optional, used if schema_id is not enriched)
 	Schema json.RawMessage `json:"schema,omitempty"`
 
-	// ApplyDefaults applies default values from schema (parse action)
-	// Default: true for parse, false for produce
+	// ApplyDefaults applies default values from schema for fields that are missing in the input.
+	// Default: true for both parse and produce.
+	// Set explicitly to false to skip default injection (e.g. when the caller guarantees all fields are present).
 	ApplyDefaults *bool `json:"apply_defaults,omitempty"`
 
 	// StructureData removes fields not defined in schema
@@ -61,13 +62,13 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// GetApplyDefaults returns the apply_defaults value with action-specific defaults
+// GetApplyDefaults returns the apply_defaults value, defaulting to true for both actions.
+// Schema defaults only fill in missing fields and never overwrite existing values.
 func (c *Config) GetApplyDefaults() bool {
 	if c.ApplyDefaults != nil {
 		return *c.ApplyDefaults
 	}
-	// Default to true for parse (to fill in missing fields), false for produce
-	return c.Action == "parse"
+	return true
 }
 
 // GetStructureData returns the structure_data value with action-specific defaults

--- a/pkg/embedded/processors/jsonops/produce.go
+++ b/pkg/embedded/processors/jsonops/produce.go
@@ -58,12 +58,12 @@ func (n *JsonOpsNode) executeProduce(input runtime.ProcessInput, cfg *Config) ru
 		))
 	}
 
-	// Process with schema (no defaults on produce, structure and validate)
+	// Process with schema: apply defaults per config, structure and validate
 	result, err := engine.ProcessWithSchema(
 		dataToProcess,
 		cfg.Schema,
 		schema.ProcessOptions{
-			ApplyDefaults: false,
+			ApplyDefaults: cfg.GetApplyDefaults(),
 			StructureData: cfg.GetStructureData(),
 		},
 	)

--- a/pkg/embedded/processors/jsonops/tests/config_test.go
+++ b/pkg/embedded/processors/jsonops/tests/config_test.go
@@ -43,8 +43,8 @@ func TestConfigDefaults(t *testing.T) {
 	}
 
 	cfgProduce := jsonops.Config{Action: "produce", SchemaID: "sid"}
-	if cfgProduce.GetApplyDefaults() {
-		t.Fatalf("produce should default apply_defaults false")
+	if !cfgProduce.GetApplyDefaults() {
+		t.Fatalf("produce should default apply_defaults true")
 	}
 	if !cfgProduce.GetStructureData() {
 		t.Fatalf("produce should default structure_data true")

--- a/pkg/embedded/processors/registry.go
+++ b/pkg/embedded/processors/registry.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"github.com/wehubfusion/Icarus/pkg/embedded/processors/constantvalue"
 	"github.com/wehubfusion/Icarus/pkg/embedded/processors/errornode"
 	"github.com/wehubfusion/Icarus/pkg/embedded/processors/dateformatter"
 	"github.com/wehubfusion/Icarus/pkg/embedded/processors/httpclient"
@@ -36,6 +37,9 @@ func NewProcessorRegistry() runtime.EmbeddedNodeFactory {
 
 	// Register error processor
 	factory.Register("plugin-error", errornode.NewErrorNode)
+
+	// Register constant value generator processor
+	factory.Register("plugin-constant-value-generator", constantvalue.NewConstantValueNode)
 
 	// Future processors can be registered here...
 


### PR DESCRIPTION
Introduced a new embedded node, the Constant Value Generator, which emits a predefined set of typed constant values without requiring any input. This feature includes configuration options for defining constants with specific types (string, number, boolean) and ensures proper validation and casting of values. The generator is registered in the processor registry and is accompanied by comprehensive tests to validate its functionality and error handling.