### PR TITLE
fix: Have Error field as false in nodes output even when a node has n…

### DIFF
--- a/pkg/resolver/errorsentinel.go
+++ b/pkg/resolver/errorsentinel.go
@@ -1,0 +1,44 @@
+package resolver
+
+import (
+	"strings"
+
+	embeddedrt "github.com/wehubfusion/Icarus/pkg/embedded/runtime"
+)
+
+// EnsureFlatErrorSentinels stamps `nodeID-/error: false` and
+// `nodeID-/errorDescription: ""` into flat when either key is absent for
+// the given node IDs. Never overwrites an existing `nodeID-/error` key
+// (preserves error:true from errorAsSuccess payloads).
+func EnsureFlatErrorSentinels(flat map[string]interface{}, nodeIDs ...string) {
+	for _, nodeID := range nodeIDs {
+		errorKey := nodeID + "-/" + embeddedrt.ErrorOutputKeyError
+		if _, exists := flat[errorKey]; !exists {
+			flat[errorKey] = false
+			descKey := nodeID + "-/" + embeddedrt.ErrorOutputKeyDescription
+			if _, exists := flat[descKey]; !exists {
+				flat[descKey] = ""
+			}
+		}
+	}
+}
+
+// EnsureFlatErrorSentinelsForAllNodes scans a flat StandardUnitOutput map for
+// every distinct node ID prefix (pattern "nodeId-/...") and calls
+// EnsureFlatErrorSentinels for each. This ensures cross-unit consumers never
+// see absent error keys when an upstream node succeeds without producing an
+// explicit /error field.
+func EnsureFlatErrorSentinelsForAllNodes(flat map[string]interface{}) {
+	if len(flat) == 0 {
+		return
+	}
+	seen := make(map[string]bool)
+	for key := range flat {
+		if idx := strings.Index(key, "-/"); idx > 0 {
+			seen[key[:idx]] = true
+		}
+	}
+	for nodeID := range seen {
+		EnsureFlatErrorSentinels(flat, nodeID)
+	}
+}

--- a/pkg/resolver/errorsentinel_test.go
+++ b/pkg/resolver/errorsentinel_test.go
@@ -1,0 +1,190 @@
+package resolver
+
+import (
+	"encoding/json"
+	"testing"
+
+	embeddedrt "github.com/wehubfusion/Icarus/pkg/embedded/runtime"
+	"github.com/wehubfusion/Icarus/pkg/message"
+)
+
+// ── EnsureFlatErrorSentinels ──────────────────────────────────────────────────
+
+func TestEnsureFlatErrorSentinels_StampsAbsentKeys(t *testing.T) {
+	flat := map[string]interface{}{
+		"nodeA-/data": "hello",
+	}
+	EnsureFlatErrorSentinels(flat, "nodeA")
+
+	if v, ok := flat["nodeA-/error"]; !ok || v != false {
+		t.Errorf("expected nodeA-/error == false, got %v (present=%v)", v, ok)
+	}
+	if v, ok := flat["nodeA-/errorDescription"]; !ok || v != "" {
+		t.Errorf("expected nodeA-/errorDescription == \"\", got %v (present=%v)", v, ok)
+	}
+}
+
+func TestEnsureFlatErrorSentinels_DoesNotOverwriteErrorTrue(t *testing.T) {
+	flat := map[string]interface{}{
+		"nodeA-/error":            true,
+		"nodeA-/errorDescription": "something went wrong",
+	}
+	EnsureFlatErrorSentinels(flat, "nodeA")
+
+	if v := flat["nodeA-/error"]; v != true {
+		t.Errorf("existing error:true must not be overwritten, got %v", v)
+	}
+	if v := flat["nodeA-/errorDescription"]; v != "something went wrong" {
+		t.Errorf("existing errorDescription must not be overwritten, got %v", v)
+	}
+}
+
+func TestEnsureFlatErrorSentinels_MultipleNodes(t *testing.T) {
+	flat := map[string]interface{}{
+		"parent-/data":    "x",
+		"embedded-/value": 42,
+	}
+	EnsureFlatErrorSentinels(flat, "parent", "embedded")
+
+	for _, nodeID := range []string{"parent", "embedded"} {
+		if v, ok := flat[nodeID+"-/error"]; !ok || v != false {
+			t.Errorf("%s-/error expected false, got %v (present=%v)", nodeID, v, ok)
+		}
+		if v, ok := flat[nodeID+"-/errorDescription"]; !ok || v != "" {
+			t.Errorf("%s-/errorDescription expected \"\", got %v (present=%v)", nodeID, v, ok)
+		}
+	}
+}
+
+// ── EnsureFlatErrorSentinelsForAllNodes ───────────────────────────────────────
+
+func TestEnsureFlatErrorSentinelsForAllNodes_StampsAllNodes(t *testing.T) {
+	flat := map[string]interface{}{
+		"nodeA-/data":  "hello",
+		"nodeB-/value": 99,
+	}
+	EnsureFlatErrorSentinelsForAllNodes(flat)
+
+	for _, nodeID := range []string{"nodeA", "nodeB"} {
+		if v, ok := flat[nodeID+"-/error"]; !ok || v != false {
+			t.Errorf("%s-/error expected false, got %v (present=%v)", nodeID, v, ok)
+		}
+	}
+}
+
+func TestEnsureFlatErrorSentinelsForAllNodes_PreservesExistingError(t *testing.T) {
+	flat := map[string]interface{}{
+		"nodeA-/error":            true,
+		"nodeA-/errorDescription": "boom",
+		"nodeA-/data":             nil,
+	}
+	EnsureFlatErrorSentinelsForAllNodes(flat)
+
+	if v := flat["nodeA-/error"]; v != true {
+		t.Errorf("error:true must not be overwritten, got %v", v)
+	}
+}
+
+func TestEnsureFlatErrorSentinelsForAllNodes_EmptyMap(t *testing.T) {
+	flat := map[string]interface{}{}
+	EnsureFlatErrorSentinelsForAllNodes(flat) // must not panic
+	if len(flat) != 0 {
+		t.Errorf("empty map should remain empty, got %v", flat)
+	}
+}
+
+// ── Cross-unit resolver synthesises /error defaults at read time ──────────────
+
+// TestBuildInputFromMappings_PluginErrorFalseViaFlatKey verifies that when the
+// upstream flat output has no /error key (normal success path — the node never
+// writes /error), a downstream standalone simple-condition node reading from the
+// pluginError section still receives false for the error destination field.
+// The synthesis happens in buildInputFromMappings for absent pluginError keys.
+func TestBuildInputFromMappings_PluginErrorFalseViaFlatKey(t *testing.T) {
+	// Success path: upstream node wrote data but did NOT write /error.
+	sourceFlat := map[string]interface{}{
+		"xlsx-node-/data": []interface{}{},
+	}
+
+	params := BuildInputParams{
+		UnitNodeID: "condition-node",
+		FieldMappings: []message.FieldMapping{
+			{
+				SourceNodeID:         "xlsx-node",
+				SourceSectionId:      embeddedrt.SectionPluginError,
+				SourceEndpoint:       "/" + embeddedrt.ErrorOutputKeyError,
+				DestinationEndpoints: []string{"/joberror"},
+				DataType:             "EVENT",
+				IsEventTrigger:       false,
+			},
+		},
+		SourceResults: map[string]*SourceResult{
+			"xlsx-node": {
+				NodeID:          "xlsx-node",
+				Status:          "success",
+				ProjectedFields: map[string]map[string]interface{}{},
+				RawFlatKeys:     sourceFlat,
+			},
+		},
+	}
+
+	result, err := buildInputFromMappings(params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(result, &data); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if v, ok := data["joberror"]; !ok {
+		t.Errorf("expected joberror key in output, got keys %v", data)
+	} else if v != false {
+		t.Errorf("expected joberror == false, got %v", v)
+	}
+}
+
+// TestBuildInputFromMappings_PluginErrorTrueViaFlatKey verifies the failure path:
+// when errorAsSuccess wrote error:true into the flat output, the downstream
+// simple-condition node reads it as true (synthesis must not overwrite a real error).
+func TestBuildInputFromMappings_PluginErrorTrueViaFlatKey(t *testing.T) {
+	sourceFlat := map[string]interface{}{
+		"blob-node-/error":            true,
+		"blob-node-/errorDescription": "upload failed",
+	}
+
+	params := BuildInputParams{
+		UnitNodeID: "condition-node",
+		FieldMappings: []message.FieldMapping{
+			{
+				SourceNodeID:         "blob-node",
+				SourceSectionId:      embeddedrt.SectionPluginError,
+				SourceEndpoint:       "/" + embeddedrt.ErrorOutputKeyError,
+				DestinationEndpoints: []string{"/persisterror"},
+				DataType:             "EVENT",
+				IsEventTrigger:       false,
+			},
+		},
+		SourceResults: map[string]*SourceResult{
+			"blob-node": {
+				NodeID:          "blob-node",
+				Status:          "success",
+				ProjectedFields: map[string]map[string]interface{}{},
+				RawFlatKeys:     sourceFlat,
+			},
+		},
+	}
+
+	result, err := buildInputFromMappings(params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(result, &data); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if v, ok := data["persisterror"]; !ok {
+		t.Errorf("expected persisterror key in output, got keys %v", data)
+	} else if v != true {
+		t.Errorf("expected persisterror == true, got %v", v)
+	}
+}

--- a/pkg/resolver/fieldmapping_builder.go
+++ b/pkg/resolver/fieldmapping_builder.go
@@ -987,6 +987,19 @@ func buildInputFromMappings(params BuildInputParams) ([]byte, error) {
 				}
 				continue // Skip fallback
 			}
+
+			// The key is absent from the flat output. For pluginError section
+			// mappings that is the normal success path — the upstream node
+			// completed without writing /error — so synthesise the implicit
+			// "no error" value rather than leaving the destination unset.
+			if mapping.SourceSectionId == runtime.SectionPluginError {
+				if def := pluginErrorSectionDefault(mapping.SourceEndpoint); def != nil {
+					for _, destEndpoint := range mapping.DestinationEndpoints {
+						setFieldAtPath(inputData, destEndpoint, def)
+					}
+					continue
+				}
+			}
 		}
 
 		var sourceResult *SourceResult
@@ -1676,4 +1689,20 @@ func navigateMap(data map[string]interface{}, path string) interface{} {
 	}
 
 	return current
+}
+
+// pluginErrorSectionDefault returns the implicit "no error" value for a given
+// endpoint read from the pluginError section when the key is absent from the
+// flat StandardUnitOutput. An absent key means the upstream node succeeded
+// without explicitly writing /error, so /error defaults to false and
+// /errorDescription defaults to "".
+func pluginErrorSectionDefault(sourceEndpoint string) interface{} {
+	endpoint := strings.TrimPrefix(sourceEndpoint, "/")
+	switch endpoint {
+	case runtime.ErrorOutputKeyError:
+		return false
+	case runtime.ErrorOutputKeyDescription:
+		return ""
+	}
+	return nil
 }


### PR DESCRIPTION
…o error

Enhance input resolution by synthesizing default values for the pluginError section when keys are absent. This change ensures that when the upstream node completes successfully without writing an error, the corresponding fields are populated with implicit "no error" values, preventing empty inputs for consumers. The new function `pluginErrorSectionDefault` is introduced to handle these defaults based on the endpoint type.