### PR TITLE
fix: update shouldSkipNode logic to correctly handle absent sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Each entry is tagged `` `public:` `` or `` `internal:` ``:
 
 ## [Unreleased]
 
+### Fixed
+
+- `public:` **Embedded subflow skip logic**: `shouldSkipNode` (non-iteration path) now
+  skips a downstream node when every one of its default-section sources is absent from
+  the output store, matching the per-item behaviour of `shouldSkipNodeForItem`
+  (`f8bf0ae`). Previously, a node whose sole upstream had itself been skipped would
+  run with an empty input map and surface as `status: success` rather than being
+  absent. Affects chains such as `SimpleCondition` → event-gated producer → FIELD-only
+  downstream node. (`pkg/embedded/runtime/subflow.go`)
+
 ## [0.10.0] — 2026-05-07
 
 ### Changed

--- a/pkg/embedded/runtime/subflow.go
+++ b/pkg/embedded/runtime/subflow.go
@@ -1944,8 +1944,13 @@ func (sp *SubflowProcessor) buildSingleNodeInput(
 	return input
 }
 
-// shouldSkipNode checks if a node should be skipped due to event triggers
-// or because all its default-section sources emitted error-only output.
+// shouldSkipNode checks if a node should be skipped due to event triggers, or
+// because every default-section source is either absent from the store
+// (i.e. the upstream node was itself skipped and never produced output) or
+// produced error-only output. Mirrors the per-item semantics of
+// shouldSkipNodeForItem for the non-iteration execution path; the two must
+// stay in sync, otherwise downstream nodes can run with empty input when
+// all of their default sources have been filtered out upstream.
 func (sp *SubflowProcessor) shouldSkipNode(
 	config EmbeddedNodeConfig,
 	store *NodeOutputStore,
@@ -1974,7 +1979,10 @@ func (sp *SubflowProcessor) shouldSkipNode(
 		}
 	}
 
-	// Skip if this node only consumes default (success) section and all such sources have error-only output
+	// Skip if this node only consumes the default (success) section and every such source
+	// is either absent from the store (never ran, e.g. because an upstream gate filtered
+	// it out) or produced error-only output. A missing source is treated as "no valid
+	// output" rather than a reason to keep running.
 	defaultMappings := config.GetDefaultSectionFieldMappings()
 	if len(defaultMappings) == 0 || len(defaultMappings) != len(config.GetFieldMappings()) {
 		return false
@@ -1987,10 +1995,13 @@ func (sp *SubflowProcessor) shouldSkipNode(
 		seen[m.SourceNodeId] = true
 		sourceOut, ok := store.GetOutput(m.SourceNodeId, -1)
 		if !ok {
-			return false
+			// Source was never stored — treat as absent, not a signal to keep running.
+			// (Matches shouldSkipNodeForItem; without this, a downstream node whose sole
+			// upstream was skipped would execute with an empty input map.)
+			continue
 		}
 		if !IsErrorOnlyOutput(sourceOut) {
-			return false
+			return false // At least one source has valid output — do not skip.
 		}
 	}
 	return true

--- a/pkg/embedded/runtime/subflow_filter_test.go
+++ b/pkg/embedded/runtime/subflow_filter_test.go
@@ -336,3 +336,124 @@ func TestShouldSkipNodeForItem_DoesNotSkipWhenSourceHasValidOutput(t *testing.T)
 		t.Fatal("expected condition node to NOT be skipped when its source has valid output")
 	}
 }
+
+// TestShouldSkipNode_SkipsWhenAllSourcesAbsent mirrors
+// TestShouldSkipNodeForItem_SkipsWhenAllSourcesAbsent for the non-iteration path:
+// a node whose only default-section source has no stored output (the upstream was
+// itself skipped) must be skipped instead of running with an empty input map.
+func TestShouldSkipNode_SkipsWhenAllSourcesAbsent(t *testing.T) {
+	const (
+		sourceNode   = "array-error-producer"
+		consumerNode = "error-gate-client"
+	)
+
+	sp := &SubflowProcessor{
+		nodeConfigs: []EmbeddedNodeConfig{
+			{
+				NodeId: consumerNode,
+				FieldMappings: []FieldMapping{
+					{
+						SourceNodeId:    sourceNode,
+						SourceEndpoint:  "/encoded",
+						SourceSectionId: SectionDefault,
+						DataType:        "FIELD",
+					},
+				},
+			},
+		},
+	}
+
+	config := sp.nodeConfigs[0]
+	store := NewNodeOutputStore() // sourceNode has no output in this store
+
+	if !sp.shouldSkipNode(config, store) {
+		t.Fatal("expected consumer node to be skipped when its source has no output")
+	}
+}
+
+// TestShouldSkipNode_DoesNotSkipWhenSourceHasValidOutput mirrors
+// TestShouldSkipNodeForItem_DoesNotSkipWhenSourceHasValidOutput for the non-iteration
+// path: the consumer must run when its default-section source has produced a valid,
+// non-error output.
+func TestShouldSkipNode_DoesNotSkipWhenSourceHasValidOutput(t *testing.T) {
+	const (
+		sourceNode   = "array-error-producer"
+		consumerNode = "error-gate-client"
+	)
+
+	sp := &SubflowProcessor{
+		nodeConfigs: []EmbeddedNodeConfig{
+			{
+				NodeId: consumerNode,
+				FieldMappings: []FieldMapping{
+					{
+						SourceNodeId:    sourceNode,
+						SourceEndpoint:  "/encoded",
+						SourceSectionId: SectionDefault,
+						DataType:        "FIELD",
+					},
+				},
+			},
+		},
+	}
+
+	config := sp.nodeConfigs[0]
+	store := NewNodeOutputStore()
+	store.SetSingleOutput(sourceNode, map[string]interface{}{
+		"encoded": "PID|1||...",
+	})
+
+	if sp.shouldSkipNode(config, store) {
+		t.Fatal("expected consumer node to NOT be skipped when its source has valid output")
+	}
+}
+
+// TestShouldSkipNode_HL7ValidatorReproducer captures the original production
+// scenario:
+//
+//	Hl7 Is Valid (Simple Condition) — emits {true: <hl7>, false: nil}
+//	-> Array Error Producer (event-triggered on /false; skipped when /false is nil)
+//	-> Error Gate Client (FIELD-mapped from Array Error Producer /encoded only;
+//	                      no event mapping; must skip when its only upstream
+//	                      source was skipped and therefore has no stored output)
+//
+// Before the fix in shouldSkipNode, Error Gate Client ran with an empty input
+// map and was reported as status:success rather than being absent from the
+// sync-completion response.
+func TestShouldSkipNode_HL7ValidatorReproducer(t *testing.T) {
+	const (
+		condNode   = "hl7-is-valid"
+		producer   = "array-error-producer"
+		gateClient = "error-gate-client"
+	)
+
+	sp := &SubflowProcessor{
+		nodeConfigs: []EmbeddedNodeConfig{
+			{
+				NodeId: gateClient,
+				FieldMappings: []FieldMapping{
+					{
+						SourceNodeId:    producer,
+						SourceEndpoint:  "/encoded",
+						SourceSectionId: SectionDefault,
+						DataType:        "FIELD",
+					},
+				},
+			},
+		},
+	}
+
+	config := sp.nodeConfigs[0]
+	store := NewNodeOutputStore()
+	// The Simple Condition ran and emitted {true: <hl7>, false: nil}; Array Error
+	// Producer was triggered off /false and was skipped, so it is absent from the
+	// store — exactly the production scenario.
+	store.SetSingleOutput(condNode, map[string]interface{}{
+		"true":  "MSH|^~\\&|...",
+		"false": nil,
+	})
+
+	if !sp.shouldSkipNode(config, store) {
+		t.Fatal("expected Error Gate Client to be skipped when Array Error Producer was filtered out upstream")
+	}
+}


### PR DESCRIPTION
Refactor the shouldSkipNode function to ensure that nodes are skipped when all default-section sources are either absent or produce error-only output. This change aligns the non-iteration path behavior with the per-item semantics of shouldSkipNodeForItem, preventing downstream nodes from executing with empty input when upstream nodes are skipped. Added tests to validate the new behavior in various scenarios.