### PR TITLE
chore: update Argus dependency to v0.3.6 and reflect changes in docum…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Each entry is tagged `` `public:` `` or `` `internal:` ``:
 
 ## [Unreleased]
 
+### Changed
+
+- `internal:` Argus dependency updated to `v0.3.6` (`EnvironmentID` on event structures and emitters).
+
 ### Fixed
 
 - `public:` **Embedded subflow skip logic**: `shouldSkipNode` (non-iteration path) now

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -49,7 +49,7 @@ v0.5.0 adds `github.com/wehubfusion/Argus` as a dependency for embedded node lif
 observation. If your `go.sum` pins a different version, run:
 
 ```bash
-go get github.com/wehubfusion/Argus@v0.3.4
+go get github.com/wehubfusion/Argus@v0.3.6
 go mod tidy
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -51,5 +51,3 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/wehubfusion/Argus => ../Argus

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wehubfusion/Argus v0.3.4 h1:r/eNN65Wb267M2euFleyqW4G6CZmrGU5u95RqWc0Fws=
-github.com/wehubfusion/Argus v0.3.4/go.mod h1:1/eAhRkzVPQ+4xwKGz7w40oN3MvBGVf8BYp91enIyDU=
+github.com/wehubfusion/Argus v0.3.6 h1:tUE8ahyv/+D1ib/+eM+f0JxDqJQlr/0BAgayjLXd6Ws=
+github.com/wehubfusion/Argus v0.3.6/go.mod h1:1/eAhRkzVPQ+4xwKGz7w40oN3MvBGVf8BYp91enIyDU=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=


### PR DESCRIPTION
…entation

- Updated Argus dependency version in go.mod and go.sum.
- Modified upgrade guide to instruct users to use the new Argus version.
- Added entry in CHANGELOG for the dependency update.